### PR TITLE
Manual histogram writing

### DIFF
--- a/bin/analyze_0l_2tau.cc
+++ b/bin/analyze_0l_2tau.cc
@@ -13,7 +13,8 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TString.h> // TString, Form
 #include <TError.h> // gErrorAbortLevel, kError
-#include <TH2F.h>
+#include <TH2F.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -144,6 +145,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2053,6 +2057,13 @@ int main(int argc, char* argv[])
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete jetToTauFakeRateInterface;

--- a/bin/analyze_1l_1tau.cc
+++ b/bin/analyze_1l_1tau.cc
@@ -13,6 +13,7 @@
 #include <TRandom3.h> // TRandom3
 #include <TH2.h> // TH2
 #include <TLorentzVector.h> // TLorentzVector
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -160,6 +161,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2204,6 +2208,13 @@ std::string mvaFileName_1l_1tau_evtLevelSUM_TTH_16Var = "tthAnalysis/HiggsToTauT
 
   std::cout << "countFat " << countFatTop << " " << countFatTopEntries << " " << countFatTopTruth << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
   delete dataToMCcorrectionInterface_1l_1tau_trigger;
 

--- a/bin/analyze_1l_2tau.cc
+++ b/bin/analyze_1l_2tau.cc
@@ -12,6 +12,7 @@
 #include <TError.h> // gErrorAbortLevel, kError
 #include <TRandom3.h> // TRandom3
 #include <TH2.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -148,6 +149,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2050,6 +2054,13 @@ int main(int argc, char* argv[])
     }
   }
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
   delete dataToMCcorrectionInterface_1l_2tau_trigger;
 

--- a/bin/analyze_2l_2tau.cc
+++ b/bin/analyze_2l_2tau.cc
@@ -12,6 +12,7 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TString.h> // TString, Form
 #include <TError.h> // gErrorAbortLevel, kError
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoHadTau.h" // RecoHadTau
@@ -142,6 +143,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2006,6 +2010,13 @@ int main(int argc, char* argv[])
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_2los_1tau.cc
+++ b/bin/analyze_2los_1tau.cc
@@ -11,6 +11,8 @@
 #include <TString.h> // TString, Form
 #include <TMatrixD.h> // TMatrixD
 #include <TError.h> // gErrorAbortLevel, kError
+#include <TROOT.h> // TROOT
+
 #include "tthAnalysis/HiggsToTauTau/interface/SyncNtupleManager.h" // SyncNtupleManager
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -158,6 +160,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2403,6 +2408,13 @@ int main(int argc, char* argv[])
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_2lss.cc
+++ b/bin/analyze_2lss.cc
@@ -13,6 +13,7 @@
 #include <TError.h> // gErrorAbortLevel, kError
 #include <TMath.h> // TMath::
 #include <TH2.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -130,6 +131,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2344,6 +2348,13 @@ int main(int argc, char* argv[])
   std::cout << std::endl;
   std::cout << "Sum of weights "<< evtWeightSum << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_2lss_1tau.cc
+++ b/bin/analyze_2lss_1tau.cc
@@ -13,6 +13,7 @@
 #include <TError.h> // gErrorAbortLevel, kError
 #include <TMath.h> // TMath::
 #include <TH2.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -134,6 +135,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2460,6 +2464,13 @@ TMVAInterface mva_Hjj_tagger(mvaFileName_Hjj_tagger, mvaInputVariables_Hjj_tagge
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  histogram_analyzedEntries->Write();
+  histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_2lss_1tau.cc
+++ b/bin/analyze_2lss_1tau.cc
@@ -2466,8 +2466,8 @@ TMVAInterface mva_Hjj_tagger(mvaFileName_Hjj_tagger, mvaInputVariables_Hjj_tagge
 
 //--- manually write histograms to output file
   fs.file().cd();
-  histogram_analyzedEntries->Write();
-  histogram_selectedEntries->Write();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
   HistManagerBase::writeHistograms();
 
 //--- memory clean-up

--- a/bin/analyze_3l.cc
+++ b/bin/analyze_3l.cc
@@ -10,6 +10,7 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TString.h> // TString, Form
 #include <TError.h> // gErrorAbortLevel, kError
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -125,6 +126,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -2300,6 +2304,13 @@ HadTopTagger* hadTopTagger = new HadTopTagger();
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_4l.cc
+++ b/bin/analyze_4l.cc
@@ -10,6 +10,7 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TString.h> // TString, Form
 #include <TError.h> // gErrorAbortLevel, kError
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -114,6 +115,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -1739,6 +1743,13 @@ int main(int argc, char* argv[])
   }
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete leptonFakeRateInterface;

--- a/bin/analyze_LeptonFakeRate.cc
+++ b/bin/analyze_LeptonFakeRate.cc
@@ -59,6 +59,7 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TH1.h> // TH1, TH1D
 #include <TMath.h> // TMath::Pi()
+#include <TROOT.h> // TROOT
 
 #include <boost/math/special_functions/sign.hpp> // boost::math::sign()
 #include <boost/algorithm/string/predicate.hpp> // boost::starts_with(), boost::ends_with()
@@ -436,6 +437,9 @@ main(int argc,
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if(argc < 2)
@@ -1696,7 +1700,7 @@ main(int argc,
     histogram_selectedEntries->Fill(0.);
   }
 
- std::cout << "max num. Entries = " << inputTree -> getCumulativeMaxEventCount()
+  std::cout << "max num. Entries = " << inputTree -> getCumulativeMaxEventCount()
             << " (limited by " << maxEvents << ") "
                "processed in " << inputTree -> getProcessedFileCount() << " file(s) "
                "(out of "      << inputTree -> getFileCount()          << ")\n"
@@ -1706,6 +1710,13 @@ main(int argc,
                "cut-flow table for electron events\n" << cutFlowTable_e  << "\n"
                "cut-flow table for muon events\n"     << cutFlowTable_mu << '\n';
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete muonReader;
   delete electronReader;
   delete jetReader;

--- a/bin/analyze_charge_flip.cc
+++ b/bin/analyze_charge_flip.cc
@@ -12,6 +12,7 @@
 #include <TError.h> // gErrorAbortLevel, kError
 #include <TMath.h> // TMath::
 #include <TH2.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoHadTau.h" // RecoHadTau
@@ -111,6 +112,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -1067,6 +1071,14 @@ int main(int argc, char* argv[])
             << " selected = " << selectedEntries << " (weighted = " << selectedEntries_weighted << ")\n\n";
   cutFlowTable.print(std::cout);
   std::cout << std::endl;
+
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete run_lumi_eventSelector;

--- a/bin/analyze_charge_flip_mu.cc
+++ b/bin/analyze_charge_flip_mu.cc
@@ -14,7 +14,8 @@
 #include <TEfficiency.h>
 #include <TError.h> // gErrorAbortLevel, kError
 #include <TMath.h> // TMath::
-#include <TH2.h>
+#include <TH2.h> // TH2
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJet.h" // RecoJet
@@ -88,6 +89,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -1315,6 +1319,13 @@ int main(int argc, char* argv[])
             << " analyzed = " << analyzedEntries << '\n'
             << " selected = " << selectedEntries << " (weighted = " << selectedEntries_weighted << ")\n\n";
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete run_lumi_eventSelector;

--- a/bin/analyze_jetToTauFakeRate.cc
+++ b/bin/analyze_jetToTauFakeRate.cc
@@ -13,6 +13,7 @@
 #include <TBenchmark.h> // TBenchmark
 #include <TString.h> // TString, Form
 #include <TError.h> // gErrorAbortLevel, kError
+#include <TROOT.h> // TROOT
 
 #include "tthAnalysis/HiggsToTauTau/interface/RecoLepton.h" // RecoLepton
 #include "tthAnalysis/HiggsToTauTau/interface/RecoHadTau.h" // RecoHadTau
@@ -284,6 +285,9 @@ int main(int argc, char* argv[])
 {
 //--- throw an exception in case ROOT encounters an error
   gErrorAbortLevel = kError;
+
+//--- stop ROOT from keeping track of all histograms
+  TH1::AddDirectory(false);
 
 //--- parse command-line arguments
   if ( argc < 2 ) {
@@ -1230,6 +1234,13 @@ int main(int argc, char* argv[])
   cutFlowTable.print(std::cout);
   std::cout << std::endl;
 
+//--- manually write histograms to output file
+  fs.file().cd();
+  //histogram_analyzedEntries->Write();
+  //histogram_selectedEntries->Write();
+  HistManagerBase::writeHistograms();
+
+//--- memory clean-up
   delete dataToMCcorrectionInterface;
 
   delete muonReader;

--- a/interface/HistManagerBase.h
+++ b/interface/HistManagerBase.h
@@ -26,6 +26,10 @@ public:
   virtual void
   bookHistograms(TFileDirectory & dir) = 0;
 
+  /// manually write histograms to output file (usually not necessary, as histogram writing is done automatically when output file gets closed)
+  static void
+  writeHistograms();
+
 protected:
   TH1 *
   book1D(TFileDirectory & dir,
@@ -134,6 +138,9 @@ protected:
 
   std::vector<TH1 *> histograms_;
   std::vector<TH2 *> histograms_2d_;
+
+  // global list of all histograms (1d and 2d) booked by analysis job 
+  static std::map<TDirectory *, std::vector<TH1 *>> gHistograms_;
 };
 
 edm::ParameterSet

--- a/python/configs/analyzeConfig_2lss_1tau.py
+++ b/python/configs/analyzeConfig_2lss_1tau.py
@@ -522,7 +522,7 @@ class analyzeConfig_2lss_1tau(analyzeConfig):
               if self.isBDTtraining or self.do_sync:
                 continue
 
-              # add output files of hadd_stage1 for data to list of input files for hadd_stage1_5
+              # add output files of hadd_stage1 to list of input files for hadd_stage1_5
               key_hadd_stage1_job = getKey(process_name, lepton_and_hadTau_selection_and_frWeight, lepton_charge_selection, chargeSumSelection)
               key_hadd_stage1_5_dir = getKey("hadd", lepton_and_hadTau_selection_and_frWeight, lepton_charge_selection, chargeSumSelection)
               hadd_stage1_5_job_tuple = (lepton_and_hadTau_selection_and_frWeight, lepton_charge_selection, chargeSumSelection)

--- a/src/HistManagerBase.cc
+++ b/src/HistManagerBase.cc
@@ -5,11 +5,28 @@
 
 #include <TH2.h> // TH2D
 
+std::map<TDirectory *, std::vector<TH1 *>> HistManagerBase::gHistograms_;
+
 HistManagerBase::HistManagerBase(const edm::ParameterSet & cfg)
   : process_(cfg.getParameter<std::string>("process"))
   , category_(cfg.getParameter<std::string>("category"))
   , central_or_shift_(cfg.getParameter<std::string>("central_or_shift"))
 {}
+
+void
+HistManagerBase::writeHistograms()
+{
+  for ( std::map<TDirectory *, std::vector<TH1 *>>::iterator directory = gHistograms_.begin(); directory != gHistograms_.end(); ++directory )
+  {
+    assert(directory->first);
+    directory->first->cd();
+    for ( std::vector<TH1 *>::iterator histogram = directory->second.begin(); histogram != directory->second.end(); ++histogram ) 
+    {
+      assert(*histogram);
+      (*histogram)->Write();
+    }
+  }
+}
 
 TH1 *
 HistManagerBase::book1D(TFileDirectory & dir,
@@ -27,6 +44,7 @@ HistManagerBase::book1D(TFileDirectory & dir,
     retVal->Sumw2();
   }
   histograms_.push_back(retVal);
+  gHistograms_[subdir].push_back(retVal);
   return retVal;
 }
 
@@ -56,6 +74,7 @@ HistManagerBase::book1D(TFileDirectory & dir,
     retVal->Sumw2();
   }
   histograms_.push_back(retVal);
+  gHistograms_[subdir].push_back(retVal);
   return retVal;
 }
 
@@ -87,6 +106,7 @@ HistManagerBase::book1D(TFileDirectory & dir,
       retVal->Sumw2();
     }
     histograms_.push_back(retVal);
+    gHistograms_[subdir].push_back(retVal);
   }
   return retVal;
 }
@@ -123,6 +143,7 @@ HistManagerBase::book2D(TFileDirectory & dir,
       retVal->Sumw2();
     }
     histograms_2d_.push_back(retVal);
+    gHistograms_[subdir].push_back(retVal);
   }
   return retVal;
 }
@@ -161,6 +182,7 @@ HistManagerBase::book2D(TFileDirectory & dir,
       retVal->Sumw2();
     }
     histograms_2d_.push_back(retVal);
+    gHistograms_[subdir].push_back(retVal);
   }
   return retVal;
 }
@@ -197,6 +219,7 @@ HistManagerBase::book2D(TFileDirectory & dir,
       retVal->Sumw2();
     }
     histograms_2d_.push_back(retVal);
+    gHistograms_[subdir].push_back(retVal);
   }
   return retVal;
 }


### PR DESCRIPTION
write histograms to output file manually,
to avoid that ROOT wastes large amount of time when closing output file, as reported here:
  https://root-forum.cern.ch/t/tfile-close-slow/24179/2
(and by Karl)