### PR TITLE
Use cone-pt instead of reco-pt to compute kinematic variables

### DIFF
--- a/bin/analyze_1l_1tau.cc
+++ b/bin/analyze_1l_1tau.cc
@@ -1813,7 +1813,7 @@ int main(int argc, char* argv[])
     double leg2Mass = selHadTau->mass();
     if ( leg2Mass < classic_svFit::chargedPionMass ) leg2Mass = classic_svFit::chargedPionMass;
     if ( leg2Mass > 1.5                            ) leg2Mass = 1.5;
-    measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(leg1Type, selLepton->pt(), selLepton->eta(), selLepton->phi(), leg1Mass));
+    measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(leg1Type, selLepton->cone_pt(), selLepton->eta(), selLepton->phi(), leg1Mass));
     measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(leg2Type, selHadTau->pt(), selHadTau->eta(), selHadTau->phi(), leg2Mass));
     ClassicSVfit svFitAlgo;
     svFitAlgo.addLogM_dynamic(false);
@@ -1841,11 +1841,11 @@ int main(int argc, char* argv[])
     const double tau_pt        = selHadTau->pt();
     const double tau_eta       = selHadTau->absEta();
     const double dr_lep_tau    = deltaR(selLepton->p4(), selHadTau->p4());
-    const double costS         = comp_cosThetaS(selLepton->p4(), selHadTau->p4());
-    const double mTauTauVis    = (selLepton->p4() + selHadTau->p4()).mass();
-    const double Pzeta         = comp_pZeta(selLepton->p4(), selHadTau->p4(), met.p4().px(), met.p4().py());
-    const double PzetaVis      = comp_pZetaVis(selLepton->p4(), selHadTau->p4());
-    const double PzetaComb     = comp_pZetaComb(selLepton->p4(), selHadTau->p4(), met.p4().px(), met.p4().py());
+    const double costS         = comp_cosThetaS(selLepton->cone_p4(), selHadTau->p4());
+    const double mTauTauVis    = (selLepton->cone_p4() + selHadTau->p4()).mass();
+    const double Pzeta         = comp_pZeta(selLepton->cone_p4(), selHadTau->p4(), met.p4().px(), met.p4().py());
+    const double PzetaVis      = comp_pZetaVis(selLepton->cone_p4(), selHadTau->p4());
+    const double PzetaComb     = comp_pZetaComb(selLepton->cone_p4(), selHadTau->p4(), met.p4().px(), met.p4().py());
     const double mbb           = ( selBJets_medium.size() >= 2 ) ? (selBJets_medium[0]->p4() + selBJets_medium[1]->p4()).mass() : -1.;
     const double mbb_loose     = ( selBJets_loose.size()  >= 2 ) ? (selBJets_loose[0]->p4()  + selBJets_loose[1]->p4()).mass()  : -1.;
 

--- a/bin/analyze_1l_2tau.cc
+++ b/bin/analyze_1l_2tau.cc
@@ -2010,7 +2010,7 @@ int main(int argc, char* argv[])
       const double max_dr_lep_tau  = std::max(dr_lep_tau_lead, dr_lep_tau_sublead);
       const double min_dr_tau_jet  = std::min(mindr_tau1_jet, mindr_tau2_jet);
       const double min_dr_lep_tau  = std::min(dr_lep_tau_lead, dr_lep_tau_sublead);
-      const double mTauTauVis1_sel = (selHadTau_lead->p4() + selLepton->p4()).mass();
+      const double mTauTauVis1_sel = (selHadTau_lead->p4() + selLepton->cone_p4()).mass();
       const int nLightJet          = selJets.size() - selBJets_loose.size() + selJetsForward.size();
 
       snm->read(eventInfo);

--- a/bin/analyze_2l_2tau.cc
+++ b/bin/analyze_2l_2tau.cc
@@ -1890,8 +1890,8 @@ int main(int argc, char* argv[])
       const double mbb             = selBJets_medium.size() > 1 ? (selBJets_medium[0]->p4() + selBJets_medium[1]->p4()).mass() : -1.;
       const double mbb_loose       = selBJets_loose.size() > 1 ? (selBJets_loose[0]->p4() + selBJets_loose[1]->p4()).mass() : -1.;
       const double min_dr_tau_jet  = std::min(mindr_tau1_jet, mindr_tau2_jet);
-      const double mTauTauVis1_sel = (selHadTau_lead->p4() + selLepton_lead->p4()).mass();
-      const double mTauTauVis2_sel = (selHadTau_lead->p4() + selLepton_sublead->p4()).mass();
+      const double mTauTauVis1_sel = (selHadTau_lead->p4() + selLepton_lead->cone_p4()).mass();
+      const double mTauTauVis2_sel = (selHadTau_lead->p4() + selLepton_sublead->cone_p4()).mass();
       const double max_lep_eta     = std::max(selLepton_lead->absEta(), selLepton_sublead->absEta());
       const int nLightJet          = selJets.size() - selBJets_loose.size() + selJetsForward.size();
 

--- a/bin/analyze_2los_1tau.cc
+++ b/bin/analyze_2los_1tau.cc
@@ -1879,8 +1879,8 @@ int main(int argc, char* argv[])
       }
     }
 
-    const double mTauTauVis1_sel = (selLepton_lead->p4() + selHadTau->p4()).mass();
-    const double mTauTauVis2_sel = (selLepton_sublead->p4() + selHadTau->p4()).mass();
+    const double mTauTauVis1_sel = (selLepton_lead->cone_p4() + selHadTau->p4()).mass();
+    const double mTauTauVis2_sel = (selLepton_sublead->cone_p4() + selHadTau->p4()).mass();
 
     if ( bdt_filler ) {
       bdt_filler -> operator()({ eventInfo.run, eventInfo.lumi, eventInfo.event })

--- a/bin/analyze_2lss.cc
+++ b/bin/analyze_2lss.cc
@@ -1703,8 +1703,8 @@ int main(int argc, char* argv[])
     double mT2_top_3particle = -1.;
     double mT2_top_2particle = -1.;
     double mT2_W = -1.;
-    const Particle::LorentzVector & selLeptonP4_lead = selLepton_lead->p4();
-    const Particle::LorentzVector & selLeptonP4_sublead = selLepton_sublead->p4();
+    const Particle::LorentzVector & selLeptonP4_lead = selLepton_lead->cone_p4();
+    const Particle::LorentzVector & selLeptonP4_sublead = selLepton_sublead->cone_p4();
 
     if(selJets.size() >= 2)
     {
@@ -1960,7 +1960,7 @@ int main(int argc, char* argv[])
 
     ///////////////////////////////
     // SVA variables
-    const double mass_2L           = (selLepton_lead->p4() + selLepton_sublead->p4()).mass();
+    const double mass_2L           = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4()).mass();
     const int    sum_Lep_charge    = selLepton_lead -> charge() + selLepton_sublead -> charge();
     std::string category_SVA = "mass_2L_";
     if ( selJets.size() > 3)

--- a/bin/analyze_2lss_1tau.cc
+++ b/bin/analyze_2lss_1tau.cc
@@ -1970,8 +1970,8 @@ int main(int argc, char* argv[])
     const double lep2_conePt     = comp_lep_conePt(*selLepton_sublead);
     const double mindr_tau_jet   = comp_mindr_jet(*selHadTau, selJets);
     const double mbb             = selBJets_medium.size() > 1 ?  (selBJets_medium[0]->p4() + selBJets_medium[1]->p4()).mass() : -1000;
-    const double mTauTauVis1_sel = (selLepton_lead->p4() + selHadTau->p4()).mass();
-    const double mTauTauVis2_sel = (selLepton_sublead->p4() + selHadTau->p4()).mass();
+    const double mTauTauVis1_sel = (selLepton_lead->cone_p4() + selHadTau->p4()).mass();
+    const double mTauTauVis2_sel = (selLepton_sublead->cone_p4() + selHadTau->p4()).mass();
     const double HTT             = max_mvaOutput_HTT_CSVsort4rd;
     const double HadTop_pt       = HadTop_pt_CSVsort4rd;
     double min_Deta_mostfwdJet_jet = 0;

--- a/bin/analyze_3l.cc
+++ b/bin/analyze_3l.cc
@@ -1862,7 +1862,7 @@ HadTopTagger* hadTopTagger = new HadTopTagger();
     const double min_dr_lep_jet    = std::min({ mindr_lep1_jet, mindr_lep2_jet, mindr_lep3_jet });
     const double dr_leps           = deltaR(selLepton_lead->p4(), selLepton_sublead->p4());
     const double max_lep_eta       = std::max({ selLepton_lead->absEta(), selLepton_sublead->absEta(), selLepton_third->absEta() });
-    const double mass_3L           = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4()).mass();
+    const double mass_3L           = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4()).mass();
     const int    sum_Lep_charge    = selLepton_lead -> charge() + selLepton_sublead -> charge() + selLepton_third->charge();
     const double min_dr_lep    = std::min({
       deltaR(selLepton_lead->p4(), selLepton_sublead->p4()),

--- a/bin/analyze_3l_1tau.cc
+++ b/bin/analyze_3l_1tau.cc
@@ -1633,8 +1633,8 @@ int main(int argc, char* argv[])
 //    in 3l category of ttH multilepton analysis
     const int nJet        = selJets.size();
 
-    const double mTauTauVis1_sel      = selLepton1_OS ? (selLepton1_OS->p4() + selHadTau->p4()).mass() : -1.;
-    const double mTauTauVis2_sel      = selLepton2_OS ? (selLepton2_OS->p4() + selHadTau->p4()).mass() : -1.;
+    const double mTauTauVis1_sel      = selLepton1_OS ? (selLepton1_OS->cone_p4() + selHadTau->p4()).mass() : -1.;
+    const double mTauTauVis2_sel      = selLepton2_OS ? (selLepton2_OS->cone_p4() + selHadTau->p4()).mass() : -1.;
     const double lep1_conePt          = comp_lep_conePt(*selLepton_lead);
     const double lep2_conePt          = comp_lep_conePt(*selLepton_sublead);
     const double lep3_conePt          = comp_lep_conePt(*selLepton_third);

--- a/bin/analyze_4l.cc
+++ b/bin/analyze_4l.cc
@@ -1483,7 +1483,7 @@ int main(int argc, char* argv[])
           std::cout << std::endl;
           std::cout << std::endl;
         }
-        const double mass_4L           = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4()  + selLepton_fourth->p4()).mass();
+        const double mass_4L           = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4()  + selLepton_fourth->cone_p4()).mass();
 
 //--- retrieve gen-matching flags
     std::vector<const GenMatchEntry*> genMatches = genMatchInterface.getGenMatch(selLeptons);

--- a/src/analysisAuxFunctions.cc
+++ b/src/analysisAuxFunctions.cc
@@ -463,7 +463,7 @@ massL(const std::vector<const RecoLepton *> & Leptons)
     for(auto lepton2_it = lepton1_it + 1; lepton2_it != Leptons.end(); ++lepton2_it)
     {
       const RecoLepton * lepton2 = *lepton2_it;
-      const double mass = (lepton1->p4() + lepton2->p4()).mass();
+      const double mass = (lepton1->cone_p4() + lepton2->cone_p4()).mass();
       if(mass < massFO)
       {
         massFO = mass;


### PR DESCRIPTION
Did not update the following event level variables because changing them would also change the event selection (which is now frozen):
- MHT, MET LD;
- checks against Z window (eg Z veto, H->ZZ->4l veto. counting the number of SFOS leptons around Z mass etc).

Updated:
- globally: di-lepton mass function (`massL()`);
- 1l+1tau: `costS`, `mTauTauVis`, `Pzeta`, `PzetaVis`, `PzetaComb`, `mTauTau` (the SVfit mass);
- 1l+2tau: `mTauTauVis1_sel`;
- 2l+2tau, 2lss+1tau, 2los+1tau, 3l+1tau: `mTauTauVis1_sel`, `mTauTauVis2_sel`;
- 2lss: `mass_2L`, `mT2` input variables;
- 3l/ctrl: `mass_3L`;
- 4l/ctrl: `mass_4L`.

The remaining kinematic variables are either angular ones (dR-s, differences in |eta| etc) and are thus insensitive to pT, or transverse mass variables, which already use cone-pt.