### PR TITLE
Consider only T+gamma, TTbar+gamma, W+gamma, Z+gamma to estimate Convs

### DIFF
--- a/python/configs/analyzeConfig.py
+++ b/python/configs/analyzeConfig.py
@@ -1043,6 +1043,8 @@ class analyzeConfig(object):
         nonfake_backgrounds = [ category for category in self.nonfake_backgrounds if category not in [ "WH", "ZH" ] ]
         processesToSubtract = []
         processesToSubtract.extend(nonfake_backgrounds)
+        if '0l' not in self.channel:
+            processesToSubtract.extend([ "%s_Convs" % conv_background for conv_background in self.convs_backgrounds])
         lines.append("process.addBackgroundLeptonFakes.processesToSubtract = cms.vstring(%s)" % processesToSubtract)
         lines.append("process.addBackgroundLeptonFakes.sysShifts = cms.vstring(%s)" % self.central_or_shifts)
         create_cfg(self.cfgFile_addFakes, jobOptions['cfgFile_modified'], lines)
@@ -1064,7 +1066,7 @@ class analyzeConfig(object):
         lines.append("    )")
         lines.append(")")
         processesToSubtract = [ "data_fakes" ]
-        nonfake_backgrounds = [category for category in self.nonfake_backgrounds if category not in [ "WH", "ZH" ]]
+        processesToSubtract.extend([ "%s_Convs" % conv_background for conv_background in self.convs_backgrounds ])
         lines.append("process.addBackgroundLeptonFlips.processesToSubtract = cms.vstring(%s)" % processesToSubtract)
         lines.append("process.addBackgroundLeptonFlips.sysShifts = cms.vstring(%s)" % self.central_or_shifts)
         create_cfg(self.cfgFile_addFlips, jobOptions['cfgFile_modified'], lines)

--- a/python/configs/analyzeConfig.py
+++ b/python/configs/analyzeConfig.py
@@ -437,6 +437,7 @@ class analyzeConfig(object):
         ] + [
           "HH_{}".format(decMode)  for decMode in self.decayModes_HH + [ 'fake' ]
         ]
+        self.convs_backgrounds = [ "XGamma" ]
         self.make_plots_backgrounds = [ ]
         self.make_plots_signal = "ttH"
         self.cfgFile_make_plots = os.path.join(self.template_dir, "makePlots_cfg.py")
@@ -1042,8 +1043,6 @@ class analyzeConfig(object):
         nonfake_backgrounds = [ category for category in self.nonfake_backgrounds if category not in [ "WH", "ZH" ] ]
         processesToSubtract = []
         processesToSubtract.extend(nonfake_backgrounds)
-        if '0l' not in self.channel:
-            processesToSubtract.extend([ "%s_Convs" % nonfake_background for nonfake_background in nonfake_backgrounds])
         lines.append("process.addBackgroundLeptonFakes.processesToSubtract = cms.vstring(%s)" % processesToSubtract)
         lines.append("process.addBackgroundLeptonFakes.sysShifts = cms.vstring(%s)" % self.central_or_shifts)
         create_cfg(self.cfgFile_addFakes, jobOptions['cfgFile_modified'], lines)
@@ -1066,7 +1065,6 @@ class analyzeConfig(object):
         lines.append(")")
         processesToSubtract = [ "data_fakes" ]
         nonfake_backgrounds = [category for category in self.nonfake_backgrounds if category not in [ "WH", "ZH" ]]
-        processesToSubtract.extend([ "%s_Convs" % nonfake_background for nonfake_background in nonfake_backgrounds ])
         lines.append("process.addBackgroundLeptonFlips.processesToSubtract = cms.vstring(%s)" % processesToSubtract)
         lines.append("process.addBackgroundLeptonFlips.sysShifts = cms.vstring(%s)" % self.central_or_shifts)
         create_cfg(self.cfgFile_addFlips, jobOptions['cfgFile_modified'], lines)

--- a/python/configs/analyzeConfig_1l_1tau.py
+++ b/python/configs/analyzeConfig_1l_1tau.py
@@ -552,7 +552,7 @@ class analyzeConfig_1l_1tau(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_and_hadTau_selection_and_frWeight, chargeSumSelection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_1l_2tau.py
+++ b/python/configs/analyzeConfig_1l_2tau.py
@@ -516,7 +516,7 @@ class analyzeConfig_1l_2tau(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_and_hadTau_selection_and_frWeight, hadTau_charge_selection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_2l_2tau.py
+++ b/python/configs/analyzeConfig_2l_2tau.py
@@ -555,7 +555,7 @@ class analyzeConfig_2l_2tau(analyzeConfig):
               addBackgrounds_job_Convs_tuple = ("Convs", lepton_charge_selection, hadTau_charge_selection, lepton_and_hadTau_selection_and_frWeight, chargeSumSelection)
               key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
               processes_input = []
-              for process_input_base in processes_input_base:
+              for process_input_base in self.convs_backgrounds:
                 if "HH" in process_input_base:
                   continue
                 processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_2los_1tau.py
+++ b/python/configs/analyzeConfig_2los_1tau.py
@@ -517,7 +517,7 @@ class analyzeConfig_2los_1tau(analyzeConfig):
         addBackgrounds_job_Convs_tuple = ("Convs", lepton_and_hadTau_selection_and_frWeight)
         key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
         processes_input = []
-        for process_input_base in processes_input_base:
+        for process_input_base in self.convs_backgrounds:
           if "HH" in process_input_base:
             continue
           processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_2lss.py
+++ b/python/configs/analyzeConfig_2lss.py
@@ -507,7 +507,7 @@ class analyzeConfig_2lss(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_selection_and_frWeight, lepton_charge_selection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_2lss_1tau.py
+++ b/python/configs/analyzeConfig_2lss_1tau.py
@@ -574,7 +574,7 @@ class analyzeConfig_2lss_1tau(analyzeConfig):
             addBackgrounds_job_Convs_tuple = ("Convs", lepton_and_hadTau_selection_and_frWeight, lepton_charge_selection, chargeSumSelection)
             key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
             processes_input = []
-            for process_input_base in processes_input_base:
+            for process_input_base in self.convs_backgrounds:
               if "HH" in process_input_base:
                 continue
               processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_3l.py
+++ b/python/configs/analyzeConfig_3l.py
@@ -483,7 +483,7 @@ class analyzeConfig_3l(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_selection_and_frWeight, chargeSumSelection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_3l_1tau.py
+++ b/python/configs/analyzeConfig_3l_1tau.py
@@ -538,7 +538,7 @@ class analyzeConfig_3l_1tau(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_and_hadTau_selection_and_frWeight, chargeSumSelection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_4l.py
+++ b/python/configs/analyzeConfig_4l.py
@@ -480,7 +480,7 @@ class analyzeConfig_4l(analyzeConfig):
           addBackgrounds_job_Convs_tuple = ("Convs", lepton_selection_and_frWeight, chargeSumSelection)
           key_addBackgrounds_job_Convs = getKey(*addBackgrounds_job_Convs_tuple)
           processes_input = []
-          for process_input_base in processes_input_base:
+          for process_input_base in self.convs_backgrounds:
             if "HH" in process_input_base:
               continue
             processes_input.append("%s_Convs" % process_input_base)

--- a/python/configs/analyzeConfig_WZctrl.py
+++ b/python/configs/analyzeConfig_WZctrl.py
@@ -527,7 +527,7 @@ class analyzeConfig_WZctrl(analyzeConfig):
         sample_categories.extend(self.nonfake_backgrounds)
         sample_categories.extend(self.ttHProcs)
         processes_input = []
-        for sample_category in sample_categories:
+        for sample_category in self.convs_backgrounds:
           processes_input.append("%s_Convs" % sample_category)
         self.jobOptions_addBackgrounds_sum[key_addBackgrounds_job_Convs] = {
           'inputFile' : self.outputFile_hadd_stage1_5[key_hadd_stage1_5_job],

--- a/python/configs/analyzeConfig_ZZctrl.py
+++ b/python/configs/analyzeConfig_ZZctrl.py
@@ -561,7 +561,7 @@ class analyzeConfig_ZZctrl(analyzeConfig):
           sample_categories.extend(self.nonfake_backgrounds)
           sample_categories.extend(self.ttHProcs)
           processes_input = []
-          for sample_category in sample_categories:
+          for sample_category in self.convs_backgrounds:
             processes_input.append("%s_Convs" % sample_category)
           self.jobOptions_addBackgrounds_sum[key_addBackgrounds_job_Convs] = {
             'inputFile' : self.outputFile_hadd_stage1_5[key_hadd_stage1_5_job],

--- a/python/configs/analyzeConfig_ttWctrl.py
+++ b/python/configs/analyzeConfig_ttWctrl.py
@@ -597,7 +597,7 @@ class analyzeConfig_ttWctrl(analyzeConfig):
           sample_categories.extend(self.nonfake_backgrounds)
           sample_categories.extend(self.ttHProcs)
           processes_input = []
-          for sample_category in sample_categories:
+          for sample_category in self.convs_backgrounds:
             processes_input.append("%s_Convs" % sample_category)
           self.jobOptions_addBackgrounds_sum[key_addBackgrounds_job_Convs] = {
             'inputFile' : self.outputFile_hadd_stage1_5[key_hadd_stage1_5_job],

--- a/python/configs/analyzeConfig_ttZctrl.py
+++ b/python/configs/analyzeConfig_ttZctrl.py
@@ -531,7 +531,7 @@ class analyzeConfig_ttZctrl(analyzeConfig):
         sample_categories.extend(self.nonfake_backgrounds)
         sample_categories.extend(self.ttHProcs)
         processes_input = []
-        for sample_category in sample_categories:
+        for sample_category in self.convs_backgrounds:
           processes_input.append("%s_Convs" % sample_category)
         self.jobOptions_addBackgrounds_sum[key_addBackgrounds_job_Convs] = {
           'inputFile' : self.outputFile_hadd_stage1_5[key_hadd_stage1_5_job],

--- a/python/samples/reclassifySamples.py
+++ b/python/samples/reclassifySamples.py
@@ -55,6 +55,9 @@ def reclassifySamples(samples_era_base, samples_era_hh_multilepton = None, sampl
       elif sample_name.startswith('/WGToLNuG_Tune'):
         sample_info["use_it"] = False
 
+      if sample_name.startswith(('/TGJets', '/TTGJets', '/WGTo', '/ZGTo')):
+        sample_info["sample_category"] = "XGamma"
+
     if sample_info["process_name_specific"].startswith('signal') and 'hh' in sample_info["process_name_specific"]:
       if is_nonresonant(sample_info["sample_category"]) and not sample_info["process_name_specific"].endswith('2b2v_sl'):
         # HH->bbWW single-leptonic samples are disabled because we decided to process these samples too late in ttH analysis


### PR DESCRIPTION
Solves this issue: https://github.com/HEP-KBFI/tth-htt/issues/110

What this PR does:
- reclassifies T+gamma, TTbar+gamma, W+gamma and Z+gamma (all previously `Rares`) as `XGamma`;
- estimates conversion background only from these four processes;
- uses these four processes only to estimate the conversion background.

Consequently, these four processes do no contribute to the SR as prompt, nor to the prompt subtraction in the fake background estimate (or fakes/flips MC for that matter). But they do enter the subtraction as conversions.