### PR TITLE
Automate charge flip measurement

### DIFF
--- a/python/configs/analyzeConfig.py
+++ b/python/configs/analyzeConfig.py
@@ -32,6 +32,8 @@ DKEY_RLES    = "output_rle"  # dir for the selected run:lumi:event numbers
 DKEY_HADD_RT = "hadd_cfg_rt" # dir for hadd cfg files generated during the runtime
 DKEY_SYNC    = 'sync_ntuple' # dir for storing sync Ntuples
 
+DKEY_COMBINE_OUTPUT = "combine_output" # dir for storing post-fit results (of auxiliary analyses)
+
 DIRLIST = [
     DKEY_CFGS, DKEY_DCRD, DKEY_HIST, DKEY_PLOT, DKEY_SCRIPTS, DKEY_LOGS, DKEY_RLES,
     DKEY_HADD_RT, DKEY_SYNC

--- a/python/configs/analyzeConfig_LeptonFakeRate.py
+++ b/python/configs/analyzeConfig_LeptonFakeRate.py
@@ -9,8 +9,6 @@ import codecs
 jinja_template_dir = os.path.join(
   os.getenv('CMSSW_BASE'), 'src', 'tthAnalysis', 'HiggsToTauTau', 'python', 'templates', 'LeptonFakeRate'
 )
-DKEY_COMBINE_OUTPUT="combine_output"
-
 jinja2.filters.FILTERS['os.path.basename'] = os.path.basename
 
 def getBinName(label, minValue, maxValue):
@@ -188,8 +186,8 @@ class analyzeConfig_LeptonFakeRate(analyzeConfig):
     )
 
     self.cmssw_base_dir_combine = cmssw_base_dir_combine
-    if not os.path.isdir(os.path.join(cmssw_base_dir_combine, 'src', 'CombineHarvester')) or \
-       not os.path.isdir(os.path.join(cmssw_base_dir_combine, 'src', 'HiggsAnalysis', 'CombinedLimit')):
+    if not os.path.isdir(os.path.join(self.cmssw_base_dir_combine, 'src', 'CombineHarvester')) or \
+       not os.path.isdir(os.path.join(self.cmssw_base_dir_combine, 'src', 'HiggsAnalysis', 'CombinedLimit')):
       raise ValueError('CMSSW path for combine not valid: %s' % self.cmssw_base_dir_combine)
 
     self.use_QCD_fromMC = use_QCD_fromMC

--- a/python/configs/analyzeConfig_charge_flip_mu.py
+++ b/python/configs/analyzeConfig_charge_flip_mu.py
@@ -13,6 +13,7 @@ class analyzeConfig_charge_flip_mu(analyzeConfig_charge_flip):
   def __init__(self,
         configDir,
         outputDir,
+        cmssw_base_dir_combine,
         executable_analyze,
         samples,
         lepton_selections,
@@ -59,6 +60,11 @@ class analyzeConfig_charge_flip_mu(analyzeConfig_charge_flip):
       submission_cmd        = submission_cmd,
     )
 
+    if not os.path.isdir(os.path.join(cmssw_base_dir_combine, 'src', 'CombineHarvester')) or \
+       not os.path.isdir(os.path.join(cmssw_base_dir_combine, 'src', 'HiggsAnalysis', 'CombinedLimit')) or \
+       not os.path.isdir(os.path.join(cmssw_base_dir_combine, 'src', 'tthAnalysis', 'ChargeFlipEstimation')):
+      raise ValueError('CMSSW path for combine not valid: %s' % cmssw_base_dir_combine)
+
     self.prep_dcard_processesToCopy = ["data_obs", "DY", "DY_fake", "WJets", "TTbar", "Singletop", "Diboson"]
     self.prep_dcard_signals = [ "DY" ]
 
@@ -66,8 +72,17 @@ class analyzeConfig_charge_flip_mu(analyzeConfig_charge_flip):
 
     self.cfgFile_analyze_original = os.path.join(self.template_dir, "analyze_charge_flip_mu_cfg.py")
     self.cfgFile_prep_dcard_original = os.path.join(self.template_dir, "prepareDatacards_cfg.py")
-    #self.histogramDir_prep_dcard = "charge_flip_SS_Tight"
     self.select_rle_output = select_rle_output
+
+    self.jobOptions_postFit = {
+      'signals'                : [ "data_obs", "DY" ],
+      'backgrounds'            : [ "DY_fake", "Singletop", "Diboson", "TTbar" ],
+      'lepton_type'            : 'muon',
+      'era'                    : self.era,
+      'cmssw_base_dir_combine' : cmssw_base_dir_combine,
+      'target'                 : 'fit_result_data_exclusions.root',
+    }
+    self.subMake_targets = []
 
   def createCfg_prep_dcard(self, jobOptions):
     """Fills the template of python configuration file for datacard preparation

--- a/python/templates/charge_flip/Makefile_postFit.template
+++ b/python/templates/charge_flip/Makefile_postFit.template
@@ -1,0 +1,124 @@
+.DEFAULT_GOAL := all
+SHELL := /bin/bash
+
+CMSSW_BASE = {{ cmssw_base_dir_combine }}
+INPUT_DATACARD = {{ prepare_datacard }}
+HADD_STAGE2 = {{ hadd_stage2 }}
+
+FIT_RESULT = {{ fit_result }}
+DATACARD_ROOT_DATA = {{ data_datacard }}
+DATACARD_ROOT_PSEUDODATA = {{ pseudodata_datacard }}
+
+ERA = {{ era }}
+LEPTON_TYPE = {{ lepton_type }}
+SIGNALS = {{ signals|join(" ") }}
+BACKGROUNDS = {{ backgrounds|join(" ") }}
+
+all: $(DATACARD_ROOT_DATA) $(DATACARD_ROOT_PSEUDODATA) $(FIT_RESULT) plots
+
+OUTPUT_DIR = $(dir $(FIT_RESULT))
+OUTPUT_DIR_DATA = $(OUTPUT_DIR)/data
+OUTPUT_DIR_PSEUDODATA = $(OUTPUT_DIR)/pseuddata
+OUTPUT_DATA = $(OUTPUT_DIR_DATA)/results.txt
+OUTPUT_PSEUDODATA = $(OUTPUT_DIR_PSEUDODATA)/results.txt
+
+SCRIPT_DIR=$(OUTPUT_DIR)/scripts
+LOG_DIR=$(OUTPUT_DIR)/logs
+
+CREATE_DATACARD_SCRIPT=$(SCRIPT_DIR)/create_datacard.sh
+CREATE_DATACARD_LOG=$(LOG_DIR)/create_datacard.log
+
+MAKE_FITS_DATA_SCRIPT=$(SCRIPT_DIR)/make_fits_data.sh
+MAKE_FITS_DATA_LOG=$(LOG_DIR)/make_fits_data.log
+
+MAKE_FITS_PSEUDODATA_SCRIPT=$(SCRIPT_DIR)/make_fits_pseudodata.sh
+MAKE_FITS_PSEUDODATA_LOG=$(LOG_DIR)/make_fits_pseudodata.log
+
+MAKE_FIT_PLOTS_DATA_SCRIPT=$(SCRIPT_DIR)/make_fits_data.sh
+MAKE_FIT_PLOTS_DATA_LOG=$(LOG_DIR)/make_fits_data.log
+
+MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT=$(SCRIPT_DIR)/make_fits_data.sh
+MAKE_FIT_PLOTS_PSEUDODATA_LOG=$(LOG_DIR)/make_fits_data.log
+
+PLOT_PULLS_SCRIPT = $(SCRIPT_DIR)/plot_pulls.sh
+PLOT_PULLS_LOG = $(LOG_DIR)/plot_pulls.log
+
+.PHONY: create_datacards plots plots_data plots_pseudodata clean
+
+clean:
+	rm -rf $(OUTPUT_DIR)/*
+	rm -f $(DATACARD_ROOT_DATA)
+	rm -f $(DATACARD_ROOT_PSEUDODATA)
+
+create_datacards:
+	mkdir -p $(dir $(CREATE_DATACARD_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(CREATE_DATACARD_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(CREATE_DATACARD_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- 'mkdir -p $$(dirname $(DATACARD_ROOT_DATA))\n' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- 'mkdir -p $$($(DATACARD_ROOT_PSEUDODATA))\n' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- 'create_pseudodata_datacard.py -i $(INPUT_DATACARD) -o $(DATACARD_ROOT_DATA) ' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- '-O $(DATACARD_ROOT_PSEUDODATA) -t $(LEPTON_TYPE) -s $(SIGNALS) $(BACKGROUNDS)\n' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- 'ChargeFlipDC -i $(DATACARD_ROOT_DATA) -b $(BACKGROUNDS) ' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- '-o $(OUTPUT_DIR_DATA) -y $(ERA) --is-$(LEPTON_TYPE) -f\n' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- 'ChargeFlipDC -i $(DATACARD_ROOT_PSEUDODATA) -b $(BACKGROUNDS) ' >> $(CREATE_DATACARD_SCRIPT)
+	printf -- '-o $(OUTPUT_DIR_PSEUDODATA) -y $(ERA) --is-$(LEPTON_TYPE) -f\n' >> $(CREATE_DATACARD_SCRIPT)
+	chmod +x $(CREATE_DATACARD_SCRIPT)
+	mkdir -p $(dir $(CREATE_DATACARD_LOG))
+	$(CREATE_DATACARD_SCRIPT) &> $(CREATE_DATACARD_LOG)
+
+$(DATACARD_ROOT_DATA): create_datacards
+
+$(DATACARD_ROOT_PSEUDODATA): create_datacards
+
+$(OUTPUT_DATA): $(DATACARD_ROOT_DATA)
+	mkdir -p $(dir $(MAKE_FITS_DATA_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(MAKE_FITS_DATA_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(MAKE_FITS_DATA_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(MAKE_FITS_DATA_SCRIPT)
+	printf -- 'make_fits.py -i $(OUTPUT_DIR_DATA) -o $(OUTPUT_DATA)\n' >> $(MAKE_FITS_DATA_SCRIPT)
+	chmod +x $(MAKE_FITS_DATA_SCRIPT)
+	mkdir -p $(dir $(MAKE_FITS_DATA_LOG))
+	$(MAKE_FITS_DATA_SCRIPT) &> $(MAKE_FITS_DATA_LOG)
+
+$(OUTPUT_PSEUDODATA): $(DATACARD_ROOT_PSEUDODATA)
+	mkdir -p $(dir $(MAKE_FITS_PSEUDODATA_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(MAKE_FITS_PSEUDODATA_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(MAKE_FITS_PSEUDODATA_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(MAKE_FITS_PSEUDODATA_SCRIPT)
+	printf -- 'make_fits.py -i $(OUTPUT_DIR_PSEUDODATA) -o $(OUTPUT_PSEUDODATA)\n' >> $(MAKE_FITS_PSEUDODATA_SCRIPT)
+	chmod +x $(MAKE_FITS_PSEUDODATA_SCRIPT)
+	mkdir -p $(dir $(MAKE_FITS_PSEUDODATA_LOG))
+	$(MAKE_FITS_PSEUDODATA_SCRIPT) &> $(MAKE_FITS_PSEUDODATA_LOG)
+
+plots_data: $(OUTPUT_DATA)
+	mkdir -p $(dir $(MAKE_FIT_PLOTS_DATA_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(MAKE_FIT_PLOTS_DATA_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(MAKE_FIT_PLOTS_DATA_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(MAKE_FIT_PLOTS_DATA_SCRIPT)
+	printf -- 'make_fit_plots.py -i $(OUTPUT_DIR_DATA)\n' >> $(MAKE_FIT_PLOTS_DATA_SCRIPT)
+	chmod +x $(MAKE_FIT_PLOTS_DATA_SCRIPT)
+	mkdir -p $(dir $(MAKE_FIT_PLOTS_DATA_LOG))
+	$(MAKE_FIT_PLOTS_DATA_SCRIPT) &> $(MAKE_FIT_PLOTS_DATA_LOG)
+
+plots_pseudodata: $(OUTPUT_PSEUDODATA)
+	mkdir -p $(dir $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT)
+	printf -- 'make_fit_plots.py -i $(OUTPUT_DIR_PSEUDODATA)\n' >> $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT)
+	chmod +x $(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT)
+	mkdir -p $(dir $(MAKE_FIT_PLOTS_PSEUDODATA_LOG))
+	$(MAKE_FIT_PLOTS_PSEUDODATA_SCRIPT) &> $(MAKE_FIT_PLOTS_PSEUDODATA_LOG)
+
+plots: plots_data plots_pseudodata
+
+$(FIT_RESULT): $(OUTPUT_DATA) $(OUTPUT_PSEUDODATA)
+	mkdir -p $(dir $(PLOT_PULLS_SCRIPT))
+	printf -- '#!$(SHELL)\n' > $(PLOT_PULLS_SCRIPT)
+	printf -- 'cd $(CMSSW_BASE)\n' >>  $(PLOT_PULLS_SCRIPT)
+	printf -- 'eval $$(scramv1 runtime -sh)\n' >> $(PLOT_PULLS_SCRIPT)
+	printf -- 'plot_pulls.py -f $(OUTPUT_DATA) -F $(OUTPUT_PSEUDODATA) -i $(HADD_STAGE2) -o $(OUTPUT_DIR) -l\n' >> $(PLOT_PULLS_SCRIPT)
+	chmod +x $(PLOT_PULLS_SCRIPT)
+	mkdir -p $(dir $(PLOT_PULLS_LOG))
+	$(PLOT_PULLS_SCRIPT) &> $(PLOT_PULLS_LOG)

--- a/test/tthAnalyzeRun_chargeFlip.py
+++ b/test/tthAnalyzeRun_chargeFlip.py
@@ -13,6 +13,8 @@ import re
 
 # E.g.: ./test/tthAnalyzeRun_chargeFlip.py -v 2017Dec13 -e 2017
 
+cmssw_base_dir_combine = os.path.expanduser('~/CMSSW_10_2_13') # immediate parent dir to src folder
+
 sys_choices      = [ 'full' ] + systematics.an_chargeFlip_e_opts
 systematics.full = systematics.an_chargeFlip_e
 
@@ -94,28 +96,29 @@ if __name__ == '__main__':
   analysis = analyzeConfig_charge_flip(
     configDir = os.path.join("/home",       getpass.getuser(), "ttHAnalysis", era, version),
     outputDir = os.path.join("/hdfs/local", getpass.getuser(), "ttHAnalysis", era, version),
-    executable_analyze    = "analyze_charge_flip",
-    samples               = samples,
-    lepton_selections     = [ "Tight" ],
-    jet_cleaning_by_index = jet_cleaning_by_index,
-    gen_matching_by_index = gen_matching_by_index,
-    central_or_shifts     = central_or_shifts,
-    max_files_per_job     = files_per_job,
-    era                   = era,
-    use_lumi              = True,
-    lumi                  = lumi,
-    check_output_files    = check_output_files,
-    running_method        = running_method,
-    num_parallel_jobs     = num_parallel_jobs,
-    histograms_to_fit     = {
-      "mass_ll" : {},
+    cmssw_base_dir_combine = cmssw_base_dir_combine,
+    executable_analyze     = "analyze_charge_flip",
+    samples                = samples,
+    lepton_selections      = [ "Tight" ],
+    jet_cleaning_by_index  = jet_cleaning_by_index,
+    gen_matching_by_index  = gen_matching_by_index,
+    central_or_shifts      = central_or_shifts,
+    max_files_per_job      = files_per_job,
+    era                    = era,
+    use_lumi               = True,
+    lumi                   = lumi,
+    check_output_files     = check_output_files,
+    running_method         = running_method,
+    num_parallel_jobs      = num_parallel_jobs,
+    histograms_to_fit      = {
+      "mass_ll"            : {},
       "mass_ll_ePtThrsh15" : {},
     },
-    select_rle_output     = True,
-    dry_run               = dry_run,
-    isDebug               = debug,
-    use_home              = use_home,
-    submission_cmd        = sys.argv,
+    select_rle_output      = True,
+    dry_run                = dry_run,
+    isDebug                = debug,
+    use_home               = use_home,
+    submission_cmd         = sys.argv,
   )
 
   job_statistics = analysis.create()

--- a/test/tthAnalyzeRun_chargeFlip_mu.py
+++ b/test/tthAnalyzeRun_chargeFlip_mu.py
@@ -13,6 +13,8 @@ import re
 
 # E.g.: ./test/tthAnalyzeRun_chargeFlip_mu.py -v 2017Dec13 -e 2017
 
+cmssw_base_dir_combine = os.path.expanduser('~/CMSSW_10_2_13') # immediate parent dir to src folder
+
 sys_choices      = [ 'full' ] + systematics.an_chargeFlip_mu_opts
 systematics.full = systematics.an_chargeFlip_mu
 
@@ -94,27 +96,28 @@ if __name__ == '__main__':
   analysis = analyzeConfig_charge_flip_mu(
     configDir = os.path.join("/home",       getpass.getuser(), "ttHAnalysis", era, version),
     outputDir = os.path.join("/hdfs/local", getpass.getuser(), "ttHAnalysis", era, version),
-    executable_analyze    = "analyze_charge_flip_mu",
-    samples               = samples,
-    lepton_selections     = [ "Tight" ],
-    jet_cleaning_by_index = jet_cleaning_by_index,
-    gen_matching_by_index = gen_matching_by_index,
-    central_or_shifts     = central_or_shifts,
-    max_files_per_job     = files_per_job,
-    era                   = era,
-    use_lumi              = True,
-    lumi                  = lumi,
-    check_output_files    = check_output_files,
-    running_method        = running_method,
-    num_parallel_jobs     = num_parallel_jobs,
-    histograms_to_fit     = {
+    cmssw_base_dir_combine = cmssw_base_dir_combine,
+    executable_analyze     = "analyze_charge_flip_mu",
+    samples                = samples,
+    lepton_selections      = [ "Tight" ],
+    jet_cleaning_by_index  = jet_cleaning_by_index,
+    gen_matching_by_index  = gen_matching_by_index,
+    central_or_shifts      = central_or_shifts,
+    max_files_per_job      = files_per_job,
+    era                    = era,
+    use_lumi               = True,
+    lumi                   = lumi,
+    check_output_files     = check_output_files,
+    running_method         = running_method,
+    num_parallel_jobs      = num_parallel_jobs,
+    histograms_to_fit      = {
       "mass_ll" : {},
     },
-    select_rle_output     = False,
-    dry_run               = dry_run,
-    isDebug               = debug,
-    use_home              = use_home,
-    submission_cmd        = sys.argv,
+    select_rle_output      = False,
+    dry_run                = dry_run,
+    isDebug                = debug,
+    use_home               = use_home,
+    submission_cmd         = sys.argv,
   )
 
   job_statistics = analysis.create()


### PR DESCRIPTION
Tested by generating the cfg file and makefile used in post-fit analysis, and by running the said makefile (except for the muons -- tested only up to the cfg file generation). Related: https://github.com/HEP-KBFI/tth_charge-flip_estimation/pull/1

It's not 100% automated: path names such as fit results (`fit_results_data_exclusion.root`) are still assumed here, and things like pT bin boundaries and the 21 subcategories are duplicated in both charge flip rate repository and this repository, but the workflow is good enough to produce (and reproduce!) final results.