### PR TITLE
Split trigger sys unc

### DIFF
--- a/interface/Data_to_MC_CorrectionInterface_0l_2tau_trigger.h
+++ b/interface/Data_to_MC_CorrectionInterface_0l_2tau_trigger.h
@@ -26,18 +26,15 @@ public:
   //-----------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------
-  // trigger efficiency turn-on curves for Spring16 non-reHLT MC (not yet implemented)
-  double
-  getWeight_triggerEff(TriggerSFsys central_or_shift) const;
-  //-----------------------------------------------------------------------------
-
-  //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
   double
   getSF_triggerEff(TriggerSFsys central_or_shift) const;
   //-----------------------------------------------------------------------------
 
 protected:
+  bool
+  check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
+
   std::string era_str_;
   int era_;
   std::string hadTauSelection_;

--- a/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h
+++ b/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h
@@ -33,18 +33,15 @@ public:
   //-----------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------
-  // trigger efficiency turn-on curves for MC
-  double
-  getWeight_triggerEff(TriggerSFsys central_or_shift) const;
-  //-----------------------------------------------------------------------------
-
-  //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
   double
   getSF_triggerEff(TriggerSFsys central_or_shift) const;
   //-----------------------------------------------------------------------------
 
 protected:
+  bool
+  check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
+
   std::map<std::string, TFile *> inputFiles_;
 
   std::string era_str_;

--- a/interface/Data_to_MC_CorrectionInterface_1l_2tau_trigger.h
+++ b/interface/Data_to_MC_CorrectionInterface_1l_2tau_trigger.h
@@ -34,18 +34,14 @@ public:
   //-----------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------
-  // trigger efficiency turn-on curves for MC
-  double
-  getWeight_triggerEff(TriggerSFsys central_or_shift) const;
-  //-----------------------------------------------------------------------------
-
-  //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
   double
   getSF_triggerEff(TriggerSFsys central_or_shift) const;
   //-----------------------------------------------------------------------------
 
 protected:
+  bool
+  check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
 
   std::map<std::string, TFile *> inputFiles_;
 

--- a/interface/Data_to_MC_CorrectionInterface_Base.h
+++ b/interface/Data_to_MC_CorrectionInterface_Base.h
@@ -93,6 +93,9 @@ protected:
                 const std::string & tauID_str,
                 int nof_levels);
 
+  bool
+  check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
+
   //-----------------------------------------------------------------------------
   // data/MC corrections for electron and muon identification and isolation efficiency,
   // including the cut on the ttH multilepton MVA

--- a/interface/TauTriggerSFInterface.h
+++ b/interface/TauTriggerSFInterface.h
@@ -13,13 +13,13 @@ enum class TriggerSFsys;
 
 enum class TauTriggerType
 {
-  DiTau, ETau, MuTau
+  None, DiTau, ETau, MuTau
 };
 
 class TauTriggerSFInterface
 {
 public:
-  TauTriggerSFInterface();
+  TauTriggerSFInterface(TauTriggerType triggerType = TauTriggerType::None);
   TauTriggerSFInterface(const std::string & era_str,
                         const std::string & hadTauSelection,
                         TauTriggerType triggerType);
@@ -43,8 +43,12 @@ protected:
   static std::string
   tauTriggerType_toStr(TauTriggerType triggerType);
 
+  TriggerSFsys
+  getGenericTriggerSFsys(TriggerSFsys central_or_shift) const;
+
   TauTriggerSFs2017 * eff_mvav2_;
   tau_trigger::SFProvider * eff_deep_;
+  TauTriggerType triggerType_;
 };
 
 #endif

--- a/interface/sysUncertOptions.h
+++ b/interface/sysUncertOptions.h
@@ -96,7 +96,18 @@ enum class TauIDSFsys
 enum class TriggerSFsys
 {
   central,
-  shiftUp, shiftDown,
+  shiftUp,        shiftDown,
+  shift_2lssUp,   shift_2lssDown,
+  shift_3lUp,     shift_3lDown,
+  shift_1l1tauUp, shift_1l1tauDown,
+  shift_0l2tauUp, shift_0l2tauDown,
+};
+
+enum class TriggerSFsysChoice
+{
+  any,
+  leptonOnly,
+  hadTauOnly,
 };
 
 enum
@@ -211,7 +222,8 @@ TauIDSFsys
 getTauIDSFsys_option(const std::string & central_or_shift);
 
 TriggerSFsys
-getTriggerSF_option(const std::string & central_or_shift);
+getTriggerSF_option(const std::string & central_or_shift,
+                    TriggerSFsysChoice choice);
 
 int
 getLHEscale_option(const std::string & central_or_shift);

--- a/python/analysisSettings.py
+++ b/python/analysisSettings.py
@@ -50,6 +50,12 @@ class systematics(object):
   MET_ResponseSyst     = [ "MET_RespUp",                      "MET_RespDown"                      ]
   MET_ResolutionSyst   = [ "MET_ResolUp",                     "MET_ResolDown"                     ]
 
+  triggerSF_2lss   = [ "CMS_ttHl_trigger_2lssUp",   "CMS_ttHl_trigger_2lssDown"   ]
+  triggerSF_3l     = [ "CMS_ttHl_trigger_3lUp",     "CMS_ttHl_trigger_3lDown"     ]
+  triggerSF_1l1tau = [ "CMS_ttHl_trigger_1l1tauUp", "CMS_ttHl_trigger_1l1tauDown" ]
+  triggerSF_0l2tau = [ "CMS_ttHl_trigger_0l2tauUp", "CMS_ttHl_trigger_0l2tauDown" ]
+  triggerSF_split = triggerSF_2lss + triggerSF_3l + triggerSF_1l1tau + triggerSF_0l2tau
+
   JEC_regrouped = [
     "CMS_ttHl_JESAbsoluteUp",           "CMS_ttHl_JESAbsoluteDown",
     "CMS_ttHl_JESAbsolute_EraUp",       "CMS_ttHl_JESAbsolute_EraDown",
@@ -338,8 +344,10 @@ class systematics(object):
   an_chargeFlip_mu      =    central +  muon_E
   an_chargeFlip_mu_opts = [ "central", "muon_E" ]
 
-  an_common      =    central +  JES +  JER +  tauES +  leptonIDSF +  tauIDSF +  UnclusteredEn +  btag +  FR_t +  lhe +  triggerSF +  PU +  DYMCReweighting +  DYMCNormScaleFactors  + L1PreFiring
-  an_common_opts = [ "central", "JES", "JER", "tauES", "leptonIDSF", "tauIDSF", "UnclusteredEn", "btag", "FR_t", "lhe", "triggerSF", "PU", "DYMCReweighting", "DYMCNormScaleFactors", "L1PreFiring"]
+  an_common      =    central +  JES +  JER +  tauES +  leptonIDSF +  tauIDSF +  UnclusteredEn +  btag +  FR_t +  lhe +  \
+                      triggerSF +  PU +  DYMCReweighting +  DYMCNormScaleFactors  + L1PreFiring
+  an_common_opts = [ "central", "JES", "JER", "tauES", "leptonIDSF", "tauIDSF", "UnclusteredEn", "btag", "FR_t", "lhe",
+                     "triggerSF", "PU", "DYMCReweighting", "DYMCNormScaleFactors", "L1PreFiring"]
   # CV: enable the CMS_ttHl_FRe_shape and CMS_ttHl_FRm_shape only if you plan to run compShapeSyst 1!
   an_extended      = an_common      +    FRe_shape +  FRm_shape
   an_extended_opts = an_common_opts + [ "FRe_shape", "FRm_shape" ]
@@ -353,8 +361,6 @@ class systematics(object):
   an_extended_hh      = an_extended
   an_extended_opts_hh = an_extended_opts
 
-  an_internal_no_mem      =    central +  leptonIDSF +  tauIDSF +  btag +  FR_t +  lhe +  triggerSF +  PU +  L1PreFiring +  FRe_shape +  FRm_shape +  DYMCReweighting  + DYMCNormScaleFactors  + topPtReweighting
-  an_internal_opts_no_mem = [ "central", "leptonIDSF", "tauIDSF", "btag", "FR_t", "lhe", "triggerSF", "PU", "L1PreFiring", "FRe_shape", "FRm_shape", "DYMCReweighting", "DYMCNormScaleFactors", "topPtReweighting" ]
-
-  an_internal      = an_internal_no_mem      +    MEM
-  an_internal_opts = an_internal_opts_no_mem + [ "MEM" ]
+  an_internal_no_mem = central + leptonIDSF + tauIDSF + btag + FR_t + lhe + triggerSF + PU + L1PreFiring + \
+                       FRe_shape + FRm_shape + DYMCReweighting + DYMCNormScaleFactors + topPtReweighting
+  an_internal = an_internal_no_mem + MEM + triggerSF_split

--- a/python/runConfig.py
+++ b/python/runConfig.py
@@ -238,6 +238,14 @@ class tthAnalyzeParser(argparse.ArgumentParser):
       help = 'R|Enable regrouped JEC',
     )
 
+  def add_split_trigger_sys(self, default = 'no'):
+    choices = [ 'yes', 'no', 'both' ]
+    assert(default in choices)
+    self.add_argument('-T', '--split-trigger-sys',
+      type = str, dest = 'split_trigger_sys', metavar = 'choice', default = default, required = False, choices = choices,
+      help = 'R|Split trigger systematic uncertainties (choices: %s)' % tthAnalyzeParser.cat(choices),
+    )
+
   def add_stitched(self, use_dy = False, use_wj = False, disable_dy_incl = False, disable_wj_incl = False):
     choices = [ 'dy', 'wjets', 'dy_noincl', 'wjets_noincl' ]
     default = []

--- a/src/Data_to_MC_CorrectionInterface_0l_2tau_trigger.cc
+++ b/src/Data_to_MC_CorrectionInterface_0l_2tau_trigger.cc
@@ -4,7 +4,7 @@
 #include "tthAnalysis/HiggsToTauTau/interface/analysisAuxFunctions.h" // kEra_*, get_era()
 #include "tthAnalysis/HiggsToTauTau/interface/cmsException.h" // cmsException()
 #include "tthAnalysis/HiggsToTauTau/interface/data_to_MC_corrections_auxFunctions.h" // aux::
-#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys, getTriggerSF_option()
+#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys
 #include "tthAnalysis/HiggsToTauTau/interface/lutAuxFunctions.h" // get_from_lut()
 
 #include "TauAnalysisTools/TauTriggerSFs/interface/TauTriggerSFs2017.h" // TauTriggerSFs2017
@@ -60,18 +60,13 @@ Data_to_MC_CorrectionInterface_0l_2tau_trigger::setHadTaus(double hadTau1_pt, do
 }
 
 double
-Data_to_MC_CorrectionInterface_0l_2tau_trigger::getWeight_triggerEff(TriggerSFsys central_or_shift) const
-{
-  assert(0);
-}
-
-double
 Data_to_MC_CorrectionInterface_0l_2tau_trigger::getSF_triggerEff(TriggerSFsys central_or_shift) const
 {
   if(isDEBUG_)
   {
     std::cout << get_human_line(this, __func__, __LINE__) << '\n';
   }
+  assert(check_triggerSFsys_opt(central_or_shift));
 
   double eff_2tau_tauLeg1_data = 0.;
   double eff_2tau_tauLeg1_mc   = 0.;
@@ -130,4 +125,16 @@ Data_to_MC_CorrectionInterface_0l_2tau_trigger::getSF_triggerEff(TriggerSFsys ce
   }
 
   return sf;
+}
+
+bool
+Data_to_MC_CorrectionInterface_0l_2tau_trigger::check_triggerSFsys_opt(TriggerSFsys central_or_shift) const
+{
+  return
+    central_or_shift == TriggerSFsys::central          ||
+    central_or_shift == TriggerSFsys::shiftUp          ||
+    central_or_shift == TriggerSFsys::shiftDown        ||
+    central_or_shift == TriggerSFsys::shift_0l2tauUp   ||
+    central_or_shift == TriggerSFsys::shift_0l2tauDown
+  ;
 }

--- a/src/Data_to_MC_CorrectionInterface_1l_1tau_trigger.cc
+++ b/src/Data_to_MC_CorrectionInterface_1l_1tau_trigger.cc
@@ -4,7 +4,7 @@
 #include "tthAnalysis/HiggsToTauTau/interface/analysisAuxFunctions.h" // kEra_*
 #include "tthAnalysis/HiggsToTauTau/interface/cmsException.h" // cmsException()
 #include "tthAnalysis/HiggsToTauTau/interface/data_to_MC_corrections_auxFunctions.h" // aux::
-#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys, getTriggerSF_option()
+#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys
 
 #include "TauAnalysisTools/TauTriggerSFs/interface/TauTriggerSFs2017.h" // TauTriggerSFs2017
 
@@ -107,18 +107,13 @@ Data_to_MC_CorrectionInterface_1l_1tau_trigger::setHadTaus(double hadTau_pt, dou
 }
 
 double
-Data_to_MC_CorrectionInterface_1l_1tau_trigger::getWeight_triggerEff(TriggerSFsys central_or_shift) const
-{
-  assert(0);
-}
-
-double
 Data_to_MC_CorrectionInterface_1l_1tau_trigger::getSF_triggerEff(TriggerSFsys central_or_shift) const
 {
   if(isDEBUG_)
   {
     std::cout << get_human_line(this, __func__, __LINE__) << '\n';
   }
+  assert(check_triggerSFsys_opt(central_or_shift));
 
   double eff_1l_data            = 0.;
   double eff_1l_mc              = 0.;
@@ -248,4 +243,16 @@ Data_to_MC_CorrectionInterface_1l_1tau_trigger::getSF_triggerEff(TriggerSFsys ce
   } // isTriggered_*
 
   return sf;
+}
+
+bool
+Data_to_MC_CorrectionInterface_1l_1tau_trigger::check_triggerSFsys_opt(TriggerSFsys central_or_shift) const
+{
+  return
+    central_or_shift == TriggerSFsys::central          ||
+    central_or_shift == TriggerSFsys::shiftUp          ||
+    central_or_shift == TriggerSFsys::shiftDown        ||
+    central_or_shift == TriggerSFsys::shift_1l1tauUp   ||
+    central_or_shift == TriggerSFsys::shift_1l1tauDown
+  ;
 }

--- a/src/Data_to_MC_CorrectionInterface_1l_2tau_trigger.cc
+++ b/src/Data_to_MC_CorrectionInterface_1l_2tau_trigger.cc
@@ -4,7 +4,7 @@
 #include "tthAnalysis/HiggsToTauTau/interface/analysisAuxFunctions.h" // kEra_2017
 #include "tthAnalysis/HiggsToTauTau/interface/cmsException.h" // cmsException()
 #include "tthAnalysis/HiggsToTauTau/interface/data_to_MC_corrections_auxFunctions.h" // aux::
-#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys, getTriggerSF_option()
+#include "tthAnalysis/HiggsToTauTau/interface/sysUncertOptions.h" // TriggerSFsys
 
 #include "TauAnalysisTools/TauTriggerSFs/interface/TauTriggerSFs2017.h" // TauTriggerSFs2017
 
@@ -118,18 +118,13 @@ Data_to_MC_CorrectionInterface_1l_2tau_trigger::setHadTaus(double hadTau1_pt, do
 }
 
 double
-Data_to_MC_CorrectionInterface_1l_2tau_trigger::getWeight_triggerEff(TriggerSFsys central_or_shift) const
-{
-  assert(0);
-}
-
-double
 Data_to_MC_CorrectionInterface_1l_2tau_trigger::getSF_triggerEff(TriggerSFsys central_or_shift) const
 {
   if(isDEBUG_)
   {
     std::cout << get_human_line(this, __func__, __LINE__) << '\n';
   }
+  assert(check_triggerSFsys_opt(central_or_shift));
 
   double eff_1l_data             = 0.;
   double eff_1l_mc               = 0.;
@@ -282,4 +277,16 @@ Data_to_MC_CorrectionInterface_1l_2tau_trigger::getSF_triggerEff(TriggerSFsys ce
   } // isTriggered_*
 
   return sf;
+}
+
+bool
+Data_to_MC_CorrectionInterface_1l_2tau_trigger::check_triggerSFsys_opt(TriggerSFsys central_or_shift) const
+{
+  return
+    central_or_shift == TriggerSFsys::central          ||
+    central_or_shift == TriggerSFsys::shiftUp          ||
+    central_or_shift == TriggerSFsys::shiftDown        ||
+    central_or_shift == TriggerSFsys::shift_1l1tauUp   ||
+    central_or_shift == TriggerSFsys::shift_1l1tauDown
+  ;
 }

--- a/src/Data_to_MC_CorrectionInterface_2016.cc
+++ b/src/Data_to_MC_CorrectionInterface_2016.cc
@@ -159,6 +159,7 @@ Data_to_MC_CorrectionInterface_2016::~Data_to_MC_CorrectionInterface_2016()
 double
 Data_to_MC_CorrectionInterface_2016::getSF_leptonTriggerEff(TriggerSFsys central_or_shift) const
 {
+  assert(check_triggerSFsys_opt(central_or_shift));
   // see https://cernbox.cern.ch/index.php/s/lW2BiTli5tJR0MN
   double sf = 1.;
   double sfErr = 0.;
@@ -187,15 +188,21 @@ Data_to_MC_CorrectionInterface_2016::getSF_leptonTriggerEff(TriggerSFsys central
   }
 
   sfErr /= 100.;
-  switch(central_or_shift)
+  if(central_or_shift == TriggerSFsys::central)
   {
-    case TriggerSFsys::central:   return sf;
-    case TriggerSFsys::shiftUp:   return sf * (1. + sfErr);
-    case TriggerSFsys::shiftDown: return sf * (1. - sfErr);
-    default: throw cmsException(this, __func__, __LINE__)
-                     << "Invalid option: " << static_cast<int>(central_or_shift)
-                   ;
+    return sf;
   }
-
-  return sf;
+  else if(central_or_shift == TriggerSFsys::shiftUp      ||
+          central_or_shift == TriggerSFsys::shift_2lssUp ||
+          central_or_shift == TriggerSFsys::shift_3lUp)
+  {
+    return sf * (1. + sfErr);
+  }
+  else if(central_or_shift == TriggerSFsys::shiftDown      ||
+          central_or_shift == TriggerSFsys::shift_2lssDown ||
+          central_or_shift == TriggerSFsys::shift_3lDown)
+  {
+    return sf * (1. - sfErr);
+  }
+  throw cmsException(this, __func__, __LINE__) << "Invalid option: " << static_cast<int>(central_or_shift);
 }

--- a/src/Data_to_MC_CorrectionInterface_2017.cc
+++ b/src/Data_to_MC_CorrectionInterface_2017.cc
@@ -122,6 +122,7 @@ Data_to_MC_CorrectionInterface_2017::~Data_to_MC_CorrectionInterface_2017()
 double
 Data_to_MC_CorrectionInterface_2017::getSF_leptonTriggerEff(TriggerSFsys central_or_shift) const
 {
+  assert(check_triggerSFsys_opt(central_or_shift));
   // see https://cernbox.cern.ch/index.php/s/lW2BiTli5tJR0MN
   double sf = 1.;
   double sfErr = 0.;
@@ -154,15 +155,21 @@ Data_to_MC_CorrectionInterface_2017::getSF_leptonTriggerEff(TriggerSFsys central
   }
 
   sfErr /= 100.;
-  switch(central_or_shift)
+  if(central_or_shift == TriggerSFsys::central)
   {
-    case TriggerSFsys::central:   return sf;
-    case TriggerSFsys::shiftUp:   return sf * (1. + sfErr);
-    case TriggerSFsys::shiftDown: return sf * (1. - sfErr);
-    default: throw cmsException(this, __func__, __LINE__)
-                     << "Invalid option: " << static_cast<int>(central_or_shift)
-                   ;
+    return sf;
   }
-
-  return sf;
+  else if(central_or_shift == TriggerSFsys::shiftUp      ||
+          central_or_shift == TriggerSFsys::shift_2lssUp ||
+          central_or_shift == TriggerSFsys::shift_3lUp)
+  {
+    return sf * (1. + sfErr);
+  }
+  else if(central_or_shift == TriggerSFsys::shiftDown      ||
+          central_or_shift == TriggerSFsys::shift_2lssDown ||
+          central_or_shift == TriggerSFsys::shift_3lDown)
+  {
+    return sf * (1. - sfErr);
+  }
+  throw cmsException(this, __func__, __LINE__) << "Invalid option: " << static_cast<int>(central_or_shift);
 }

--- a/src/Data_to_MC_CorrectionInterface_2018.cc
+++ b/src/Data_to_MC_CorrectionInterface_2018.cc
@@ -103,6 +103,7 @@ Data_to_MC_CorrectionInterface_2018::~Data_to_MC_CorrectionInterface_2018()
 double
 Data_to_MC_CorrectionInterface_2018::getSF_leptonTriggerEff(TriggerSFsys central_or_shift) const
 {
+  assert(check_triggerSFsys_opt(central_or_shift));
   // see https://cernbox.cern.ch/index.php/s/lW2BiTli5tJR0MN
   double sf = 1.;
   double sfErr = 0.;
@@ -135,15 +136,21 @@ Data_to_MC_CorrectionInterface_2018::getSF_leptonTriggerEff(TriggerSFsys central
   }
 
   sfErr /= 100.;
-  switch(central_or_shift)
+  if(central_or_shift == TriggerSFsys::central)
   {
-    case TriggerSFsys::central:   return sf;
-    case TriggerSFsys::shiftUp:   return sf * (1. + sfErr);
-    case TriggerSFsys::shiftDown: return sf * (1. - sfErr);
-    default: throw cmsException(this, __func__, __LINE__)
-                     << "Invalid option: " << static_cast<int>(central_or_shift)
-                   ;
+    return sf;
   }
-
-  return sf;
+  else if(central_or_shift == TriggerSFsys::shiftUp      ||
+          central_or_shift == TriggerSFsys::shift_2lssUp ||
+          central_or_shift == TriggerSFsys::shift_3lUp)
+  {
+    return sf * (1. + sfErr);
+  }
+  else if(central_or_shift == TriggerSFsys::shiftDown      ||
+          central_or_shift == TriggerSFsys::shift_2lssDown ||
+          central_or_shift == TriggerSFsys::shift_3lDown)
+  {
+    return sf * (1. - sfErr);
+  }
+  throw cmsException(this, __func__, __LINE__) << "Invalid option: " << static_cast<int>(central_or_shift);
 }

--- a/src/Data_to_MC_CorrectionInterface_Base.cc
+++ b/src/Data_to_MC_CorrectionInterface_Base.cc
@@ -310,6 +310,28 @@ Data_to_MC_CorrectionInterface_Base::init_tauIDSFs(const std::string & era_str,
   }
 }
 
+bool
+Data_to_MC_CorrectionInterface_Base::check_triggerSFsys_opt(TriggerSFsys central_or_shift) const
+{
+  if(central_or_shift == TriggerSFsys::central ||
+     central_or_shift == TriggerSFsys::shiftUp ||
+     central_or_shift == TriggerSFsys::shiftDown)
+  {
+    return true;
+  }
+  if(central_or_shift == TriggerSFsys::shift_2lssUp ||
+     central_or_shift == TriggerSFsys::shift_2lssDown)
+  {
+    return numLeptons_ <= 2 && numHadTaus_ <= 2;
+  }
+  if(central_or_shift == TriggerSFsys::shift_3lUp ||
+     central_or_shift == TriggerSFsys::shift_3lDown)
+  {
+    return numLeptons_ >= 3 && numHadTaus_ <= 1;
+  }
+  return false;
+}
+
 double
 Data_to_MC_CorrectionInterface_Base::getSF_leptonID_and_Iso_loose() const
 {

--- a/src/EvtWeightRecorder.cc
+++ b/src/EvtWeightRecorder.cc
@@ -214,14 +214,15 @@ EvtWeightRecorder::get_sf_triggerEff(const std::string & central_or_shift) const
   double sf_triggerEff = 1.;
   if(isMC_ && (! weights_leptonTriggerEff_.empty() || ! weights_tauTriggerEff_.empty()))
   {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift);
-    if(weights_leptonTriggerEff_.count(triggerSF_option))
+    const TriggerSFsys triggerSF_lepton_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::leptonOnly);
+    if(weights_leptonTriggerEff_.count(triggerSF_lepton_option))
     {
-      sf_triggerEff *= weights_leptonTriggerEff_.at(triggerSF_option);
+      sf_triggerEff *= weights_leptonTriggerEff_.at(triggerSF_lepton_option);
     }
-    if(weights_tauTriggerEff_.count(triggerSF_option))
+    const TriggerSFsys triggerSF_hadTau_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
+    if(weights_tauTriggerEff_.count(triggerSF_hadTau_option))
     {
-      sf_triggerEff *= weights_tauTriggerEff_.at(triggerSF_option);
+      sf_triggerEff *= weights_tauTriggerEff_.at(triggerSF_hadTau_option);
     }
   }
   return sf_triggerEff;
@@ -560,7 +561,7 @@ EvtWeightRecorder::record_leptonTriggerEff(const Data_to_MC_CorrectionInterface_
   weights_leptonTriggerEff_.clear();
   for(const std::string & central_or_shift: central_or_shifts_)
   {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift);
+    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::leptonOnly);
     if(weights_leptonTriggerEff_.count(triggerSF_option))
     {
       continue;
@@ -576,7 +577,7 @@ EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_0l_
   weights_tauTriggerEff_.clear();
   for(const std::string & central_or_shift: central_or_shifts_)
   {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift);
+    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
     if(weights_tauTriggerEff_.count(triggerSF_option))
     {
       continue;
@@ -592,7 +593,7 @@ EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_
   weights_tauTriggerEff_.clear();
   for(const std::string & central_or_shift: central_or_shifts_)
   {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift);
+    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
     if(weights_tauTriggerEff_.count(triggerSF_option))
     {
       continue;
@@ -608,7 +609,7 @@ EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_
   weights_tauTriggerEff_.clear();
   for(const std::string & central_or_shift: central_or_shifts_)
   {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift);
+    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
     if(weights_tauTriggerEff_.count(triggerSF_option))
     {
       continue;

--- a/src/TauTriggerSFInterface.cc
+++ b/src/TauTriggerSFInterface.cc
@@ -16,19 +16,21 @@ TauTriggerSFInterface::tauTriggerType_toStr(TauTriggerType triggerType)
     case TauTriggerType::DiTau: return "ditau";
     case TauTriggerType::ETau:  return "etau";
     case TauTriggerType::MuTau: return "mutau";
+    case TauTriggerType::None: __attribute__((fallthrough));
     default: throw cmsException(__func__, __LINE__) << "Invalid trigger type: " << as_integer(triggerType);
   }
 }
 
-TauTriggerSFInterface::TauTriggerSFInterface()
+TauTriggerSFInterface::TauTriggerSFInterface(TauTriggerType triggerType)
   : eff_mvav2_(nullptr)
   , eff_deep_(nullptr)
+  , triggerType_(triggerType)
 {}
 
 TauTriggerSFInterface::TauTriggerSFInterface(const std::string & era_str,
                                              const std::string & hadTauSelection,
                                              TauTriggerType triggerType)
-  : TauTriggerSFInterface()
+  : TauTriggerSFInterface(triggerType)
 {
   const int __attribute__((unused)) era = get_era(era_str);
   const TauID tauId = get_tau_id_enum(hadTauSelection);
@@ -67,20 +69,38 @@ TauTriggerSFInterface::getTauTriggerEvalData(TriggerSFsys central_or_shift,
 {
   if(eff_mvav2_)
   {
-    switch(central_or_shift)
+    switch(getGenericTriggerSFsys(central_or_shift))
     {
-      case TriggerSFsys::central:   return eff_mvav2_->getTriggerEfficiencyData          (pt, eta, phi, dm);
-      case TriggerSFsys::shiftUp:   return eff_mvav2_->getTriggerEfficiencyDataUncertUp  (pt, eta, phi, dm);
-      case TriggerSFsys::shiftDown: return eff_mvav2_->getTriggerEfficiencyDataUncertDown(pt, eta, phi, dm);
+      case TriggerSFsys::central:          return eff_mvav2_->getTriggerEfficiencyData          (pt, eta, phi, dm);
+      case TriggerSFsys::shiftUp:          return eff_mvav2_->getTriggerEfficiencyDataUncertUp  (pt, eta, phi, dm);
+      case TriggerSFsys::shiftDown:        return eff_mvav2_->getTriggerEfficiencyDataUncertDown(pt, eta, phi, dm);
+      case TriggerSFsys::shift_2lssUp:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_2lssDown:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lUp:       __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lDown:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauDown: __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauDown: __attribute__((fallthrough));
+      default: assert(false);
     }
   }
   else if(eff_deep_)
   {
-    switch(central_or_shift)
+    switch(getGenericTriggerSFsys(central_or_shift))
     {
-      case TriggerSFsys::central:   return eff_deep_->getEfficiencyData(pt, dm,  0);
-      case TriggerSFsys::shiftUp:   return eff_deep_->getEfficiencyData(pt, dm, +1);
-      case TriggerSFsys::shiftDown: return eff_deep_->getEfficiencyData(pt, dm, -1);
+      case TriggerSFsys::central:          return eff_deep_->getEfficiencyData(pt, dm,  0);
+      case TriggerSFsys::shiftUp:          return eff_deep_->getEfficiencyData(pt, dm, +1);
+      case TriggerSFsys::shiftDown:        return eff_deep_->getEfficiencyData(pt, dm, -1);
+      case TriggerSFsys::shift_2lssUp:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_2lssDown:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lUp:       __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lDown:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauDown: __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauDown: __attribute__((fallthrough));
+      default: assert(false);
     }
   }
   throw cmsException(this, __func__, __LINE__) << "Class not initialized properly";
@@ -96,25 +116,81 @@ TauTriggerSFInterface::getTauTriggerEvalMC(TriggerSFsys central_or_shift,
 {
   if(eff_mvav2_)
   {
-    switch(central_or_shift)
+    switch(getGenericTriggerSFsys(central_or_shift))
     {
-      case TriggerSFsys::central:   return eff_mvav2_->getTriggerEfficiencyMC          (pt, eta, phi, dm);
-      case TriggerSFsys::shiftUp:   return flip ?
+      case TriggerSFsys::central:          return eff_mvav2_->getTriggerEfficiencyMC   (pt, eta, phi, dm);
+      case TriggerSFsys::shiftUp:          return flip ?
                                            eff_mvav2_->getTriggerEfficiencyMCUncertDown(pt, eta, phi, dm) :
                                            eff_mvav2_->getTriggerEfficiencyMCUncertUp  (pt, eta, phi, dm);
-      case TriggerSFsys::shiftDown: return flip ?
+      case TriggerSFsys::shiftDown:        return flip ?
                                            eff_mvav2_->getTriggerEfficiencyMCUncertUp  (pt, eta, phi, dm) :
                                            eff_mvav2_->getTriggerEfficiencyMCUncertDown(pt, eta, phi, dm);
+      case TriggerSFsys::shift_2lssUp:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_2lssDown:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lUp:       __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lDown:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauDown: __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauDown: __attribute__((fallthrough));
+      default: assert(false);
     }
   }
   else if(eff_deep_)
   {
-    switch(central_or_shift)
+    switch(getGenericTriggerSFsys(central_or_shift))
     {
-      case TriggerSFsys::central:   return eff_deep_->getEfficiencyMC(pt, dm,  0);
-      case TriggerSFsys::shiftUp:   return eff_deep_->getEfficiencyMC(pt, dm, flip ? -1 : +1);
-      case TriggerSFsys::shiftDown: return eff_deep_->getEfficiencyMC(pt, dm, flip ? +1 : -1);
+      case TriggerSFsys::central:          return eff_deep_->getEfficiencyMC(pt, dm,  0);
+      case TriggerSFsys::shiftUp:          return eff_deep_->getEfficiencyMC(pt, dm, flip ? -1 : +1);
+      case TriggerSFsys::shiftDown:        return eff_deep_->getEfficiencyMC(pt, dm, flip ? +1 : -1);
+      case TriggerSFsys::shift_2lssUp:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_2lssDown:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lUp:       __attribute__((fallthrough));
+      case TriggerSFsys::shift_3lDown:     __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_1l1tauDown: __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauUp:   __attribute__((fallthrough));
+      case TriggerSFsys::shift_0l2tauDown: __attribute__((fallthrough));
+      default: assert(false);
     }
   }
   throw cmsException(this, __func__, __LINE__) << "Class not initialized properly";
+}
+
+TriggerSFsys
+TauTriggerSFInterface::getGenericTriggerSFsys(TriggerSFsys central_or_shift) const
+{
+  if(central_or_shift == TriggerSFsys::central ||
+     central_or_shift == TriggerSFsys::shiftUp ||
+     central_or_shift == TriggerSFsys::shiftDown)
+  {
+    return central_or_shift;
+  }
+  else if(central_or_shift == TriggerSFsys::shift_0l2tauUp ||
+          central_or_shift == TriggerSFsys::shift_0l2tauDown)
+  {
+    if(triggerType_ != TauTriggerType::DiTau)
+    {
+      throw cmsException(this, __func__, __LINE__)
+        << "Invalid choice of systematic uncertatinty (" << as_integer(central_or_shift) << ") "
+           "for the trigger type " << as_integer(triggerType_)
+      ;
+    }
+    return central_or_shift == TriggerSFsys::shift_0l2tauUp ? TriggerSFsys::shiftUp : TriggerSFsys::shiftDown;
+  }
+  else if(central_or_shift == TriggerSFsys::shift_1l1tauUp ||
+          central_or_shift == TriggerSFsys::shift_1l1tauDown)
+  {
+    if(triggerType_ != TauTriggerType::ETau && triggerType_ != TauTriggerType::MuTau)
+    {
+      throw cmsException(this, __func__, __LINE__)
+        << "Invalid choice of systematic uncertatinty (" << as_integer(central_or_shift) << ") "
+           "for the trigger type " << as_integer(triggerType_)
+      ;
+    }
+    return central_or_shift == TriggerSFsys::shift_1l1tauUp ? TriggerSFsys::shiftUp : TriggerSFsys::shiftDown;
+  }
+  throw cmsException(this, __func__, __LINE__)
+      << "Invalid choice of systematic uncertainty:" << as_integer(central_or_shift)
+  ;
 }

--- a/src/sysUncertOptions.cc
+++ b/src/sysUncertOptions.cc
@@ -177,11 +177,23 @@ getTauIDSFsys_option(const std::string & central_or_shift)
 }
 
 TriggerSFsys
-getTriggerSF_option(const std::string & central_or_shift)
+getTriggerSF_option(const std::string & central_or_shift,
+                    TriggerSFsysChoice choice)
 {
+  const bool isLeptonCompatible = choice == TriggerSFsysChoice::any || choice == TriggerSFsysChoice::leptonOnly;
+  const bool isHadTauCompatible = choice == TriggerSFsysChoice::any || choice == TriggerSFsysChoice::hadTauOnly;
+  const bool isAnyCompatible = isLeptonCompatible || isHadTauCompatible;
   TriggerSFsys central_or_shift_int = TriggerSFsys::central;
-  if     (central_or_shift == "CMS_ttHl_triggerUp"  ) central_or_shift_int = TriggerSFsys::shiftUp;
-  else if(central_or_shift == "CMS_ttHl_triggerDown") central_or_shift_int = TriggerSFsys::shiftDown;
+  if     (central_or_shift == "CMS_ttHl_triggerUp"          && isAnyCompatible   ) central_or_shift_int = TriggerSFsys::shiftUp;
+  else if(central_or_shift == "CMS_ttHl_triggerDown"        && isAnyCompatible   ) central_or_shift_int = TriggerSFsys::shiftDown;
+  else if(central_or_shift == "CMS_ttHl_trigger_2lssUp"     && isLeptonCompatible) central_or_shift_int = TriggerSFsys::shift_2lssUp;
+  else if(central_or_shift == "CMS_ttHl_trigger_2lssDown"   && isLeptonCompatible) central_or_shift_int = TriggerSFsys::shift_2lssDown;
+  else if(central_or_shift == "CMS_ttHl_trigger_3lUp"       && isLeptonCompatible) central_or_shift_int = TriggerSFsys::shift_3lUp;
+  else if(central_or_shift == "CMS_ttHl_trigger_3lDown"     && isLeptonCompatible) central_or_shift_int = TriggerSFsys::shift_3lDown;
+  else if(central_or_shift == "CMS_ttHl_trigger_1l1tauUp"   && isHadTauCompatible) central_or_shift_int = TriggerSFsys::shift_1l1tauUp;
+  else if(central_or_shift == "CMS_ttHl_trigger_1l1tauDown" && isHadTauCompatible) central_or_shift_int = TriggerSFsys::shift_1l1tauDown;
+  else if(central_or_shift == "CMS_ttHl_trigger_0l2tauUp"   && isHadTauCompatible) central_or_shift_int = TriggerSFsys::shift_0l2tauUp;
+  else if(central_or_shift == "CMS_ttHl_trigger_0l2tauDown" && isHadTauCompatible) central_or_shift_int = TriggerSFsys::shift_0l2tauDown;
   return central_or_shift_int;
 }
 

--- a/test/tthAnalyzeRun_0l_2tau.py
+++ b/test/tthAnalyzeRun_0l_2tau.py
@@ -34,6 +34,7 @@ parser.add_gen_matching()
 parser.add_sideband()
 parser.do_MC_only()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -63,11 +64,19 @@ sideband          = args.sideband
 tau_id            = args.tau_id
 MC_only           = args.MC_only
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_0l2tau)
+  systematics.full.extend(systematics.triggerSF_0l2tau)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_1l_1tau.py
+++ b/test/tthAnalyzeRun_1l_1tau.py
@@ -33,6 +33,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.do_MC_only()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -61,11 +62,19 @@ gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 MC_only           = args.MC_only
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_1l1tau)
+  systematics.full.extend(systematics.triggerSF_1l1tau)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_1l_2tau.py
+++ b/test/tthAnalyzeRun_1l_2tau.py
@@ -33,6 +33,7 @@ parser.add_gen_matching()
 parser.add_sideband()
 parser.do_MC_only()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -62,11 +63,19 @@ sideband          = args.sideband
 tau_id            = args.tau_id
 MC_only           = args.MC_only
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_1l1tau)
+  systematics.full.extend(systematics.triggerSF_1l1tau)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_2l_2tau.py
+++ b/test/tthAnalyzeRun_2l_2tau.py
@@ -32,6 +32,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -60,11 +61,19 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_2lss)
+  systematics.full.extend(systematics.triggerSF_2lss)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_2los_1tau.py
+++ b/test/tthAnalyzeRun_2los_1tau.py
@@ -31,6 +31,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.do_MC_only()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -59,11 +60,19 @@ gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 MC_only           = args.MC_only
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_2lss)
+  systematics.full.extend(systematics.triggerSF_2lss)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_2lss.py
+++ b/test/tthAnalyzeRun_2lss.py
@@ -30,6 +30,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_tau_id()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 parser.add_stitched()
 args = parser.parse_args()
 
@@ -59,11 +60,19 @@ gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
 use_stitched      = args.use_stitched
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_2lss)
+  systematics.full.extend(systematics.triggerSF_2lss)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_2lss_1tau.py
+++ b/test/tthAnalyzeRun_2lss_1tau.py
@@ -35,6 +35,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -63,11 +64,19 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_2lss)
+  systematics.full.extend(systematics.triggerSF_2lss)
 
 # Use the arguments
 if "MEM" in mode:

--- a/test/tthAnalyzeRun_3l.py
+++ b/test/tthAnalyzeRun_3l.py
@@ -35,6 +35,7 @@ parser.add_sideband()
 parser.add_tau_id()
 parser.add_control_region()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -64,11 +65,19 @@ sideband          = args.sideband
 tau_id            = args.tau_id
 control_region    = args.control_region
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 if "MEM" in mode:

--- a/test/tthAnalyzeRun_3l_1tau.py
+++ b/test/tthAnalyzeRun_3l_1tau.py
@@ -34,6 +34,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -62,11 +63,19 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_4l.py
+++ b/test/tthAnalyzeRun_4l.py
@@ -32,6 +32,7 @@ parser.add_sideband()
 parser.add_tau_id()
 parser.add_control_region()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -61,11 +62,19 @@ sideband          = args.sideband
 tau_id            = args.tau_id
 control_region    = args.control_region
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_WZctrl.py
+++ b/test/tthAnalyzeRun_WZctrl.py
@@ -30,6 +30,7 @@ parser.add_nonnominal()
 parser.add_hlt_filter()
 parser.add_tau_id()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -57,11 +58,19 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_ZZctrl.py
+++ b/test/tthAnalyzeRun_ZZctrl.py
@@ -31,6 +31,7 @@ parser.add_gen_matching()
 parser.add_sideband()
 parser.add_tau_id()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -59,11 +60,19 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_ttWctrl.py
+++ b/test/tthAnalyzeRun_ttWctrl.py
@@ -30,6 +30,7 @@ parser.add_gen_matching()
 parser.add_hlt_filter()
 parser.add_tau_id()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -57,11 +58,19 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_2lss)
+  systematics.full.extend(systematics.triggerSF_2lss)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_ttZctrl.py
+++ b/test/tthAnalyzeRun_ttZctrl.py
@@ -31,6 +31,7 @@ parser.add_nonnominal()
 parser.add_hlt_filter()
 parser.add_tau_id()
 parser.enable_regrouped_jec()
+parser.add_split_trigger_sys()
 args = parser.parse_args()
 
 # Common arguments
@@ -59,11 +60,19 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 regroup_jec       = args.enable_regrouped_jec
+split_trigger_sys = args.split_trigger_sys
 
 if regroup_jec:
   if 'full' not in systematics_label:
     raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
   systematics.full.extend(systematics.JEC_regrouped)
+if split_trigger_sys == 'yes':
+  for trigger_sys in systematics.triggerSF:
+    del systematics.internal[systematics.internal.index(trigger_sys)]
+    del systematics.full[systematics.full.index(trigger_sys)]
+if split_trigger_sys in [ 'yes', 'both' ]:
+  systematics.internal.extend(systematics.triggerSF_3l)
+  systematics.full.extend(systematics.triggerSF_3l)
 
 # Use the arguments
 central_or_shifts = []


### PR DESCRIPTION
Addresses https://github.com/HEP-KBFI/tth-htt/issues/114
The feature can be enabled with `-T/--split-trigger-sys` option which takes either of the following arguments:
- `no` (the default) keeps the variations in `CMS_ttHl_trigger`;
- `yes` splits `CMS_ttHl_triggerUp` into groups as described in the issue;
- `both` keeps `CMS_ttHl_triggerUp` but also provides the split versions.

Tested ttH 2lss and 1l+1tau channels, and HH 1l+3tau channel. The change has no effect in either of those analyses by default. However, it allows to split the trigger systematics into groups as described in the issue if needed.