### PR TITLE
Split JER & nuisance for HEM

### DIFF
--- a/bin/analyze_0l_2tau.cc
+++ b/bin/analyze_0l_2tau.cc
@@ -1276,7 +1276,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptons, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_1l_1tau.cc
+++ b/bin/analyze_1l_1tau.cc
@@ -1410,7 +1410,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_1l_2tau.cc
+++ b/bin/analyze_1l_2tau.cc
@@ -1310,7 +1310,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_2l_2tau.cc
+++ b/bin/analyze_2l_2tau.cc
@@ -1291,7 +1291,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_2los_1tau.cc
+++ b/bin/analyze_2los_1tau.cc
@@ -1332,7 +1332,8 @@ int main(int argc, char* argv[])
     const hadTauGenMatchEntry& selHadTau_genMatch = getHadTauGenMatch(hadTauGenMatch_definitions, selHadTau);
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_2lss.cc
+++ b/bin/analyze_2lss.cc
@@ -1390,7 +1390,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 presel leptons", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_2lss_1tau.cc
+++ b/bin/analyze_2lss_1tau.cc
@@ -1397,7 +1397,8 @@ int main(int argc, char* argv[])
     const hadTauGenMatchEntry& selHadTau_genMatch = getHadTauGenMatch(hadTauGenMatch_definitions, selHadTau);
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_3l.cc
+++ b/bin/analyze_3l.cc
@@ -1453,7 +1453,8 @@ HadTopTagger* hadTopTagger = new HadTopTagger();
     cutFlowHistManager->fillHistograms("Hadronic selection", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_3l_1tau.cc
+++ b/bin/analyze_3l_1tau.cc
@@ -1342,7 +1342,8 @@ int main(int argc, char* argv[])
     const hadTauGenMatchEntry& selHadTau_genMatch = getHadTauGenMatch(hadTauGenMatch_definitions, selHadTau);
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_4l.cc
+++ b/bin/analyze_4l.cc
@@ -1252,7 +1252,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_WZctrl.cc
+++ b/bin/analyze_WZctrl.cc
@@ -1112,7 +1112,8 @@ int main(int argc, char* argv[])
     cutFlowTable.update("No medium b-jets", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_ZZctrl.cc
+++ b/bin/analyze_ZZctrl.cc
@@ -1167,7 +1167,8 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms(">= 2 loose b-jets || 1 medium b-jet inverted", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_inclusive.cc
+++ b/bin/analyze_inclusive.cc
@@ -564,7 +564,8 @@ main(int argc,
     snm->read(mbb_loose,  FloatVariableType::mbb_loose);
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptons, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_ttWctrl.cc
+++ b/bin/analyze_ttWctrl.cc
@@ -1057,7 +1057,8 @@ int main(int argc, char* argv[])
     cutFlowTable.update(">= 2 loose b-jets || 1 medium b-jet", evtWeightRecorder.get(central_or_shift_main));
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/bin/analyze_ttZctrl.cc
+++ b/bin/analyze_ttZctrl.cc
@@ -1109,7 +1109,8 @@ int main(int argc, char* argv[])
 
 
 //--- compute MHT and linear MET discriminant (met_LD)
-    const RecoMEt met = metReader->read();
+    const RecoMEt met_uncorr = metReader->read();
+    const RecoMEt met = recompute_met(met_uncorr, jets, met_option, isDEBUG);
     const Particle::LorentzVector mht_p4 = compMHT(fakeableLeptonsFull, looseHadTaus, selJets);
     const double met_LD = compMEt_LD(met.p4(), mht_p4);
 

--- a/interface/RecoJet.h
+++ b/interface/RecoJet.h
@@ -33,7 +33,8 @@ public:
           Int_t puId,
           Int_t genMatchIdx,
           Int_t idx,
-          Btag btag);
+          Btag btag,
+          Int_t central_or_shift);
 
   virtual ~RecoJet();
 
@@ -59,6 +60,9 @@ public:
 
   bool hasBtag(Btag btag) const;
 
+  int get_default_systematics() const;
+  const Particle::LorentzVector get_systematics_p4(int central_or_shift) const;
+
   friend class RecoJetReader;
   friend class RecoJetWriter;
 
@@ -81,6 +85,7 @@ protected:
   std::map<Btag, Double_t> BtagCSVs_;
   std::map<int, Double_t> pt_systematics_;
   std::map<int, Double_t> mass_systematics_;
+  int default_systematics_;
   //---------------------------------------------------------
 };
 

--- a/interface/RecoJetReader.h
+++ b/interface/RecoJetReader.h
@@ -101,7 +101,9 @@ protected:
   Btag btag_;
   int btag_central_or_shift_;
   int ptMassOption_;
+  int ptMassOption_branch_;
   bool read_ptMass_systematics_;
+  std::vector<int> read_systematics_whitelist_;
   bool read_btag_systematics_;
 
   UInt_t nJets_;

--- a/interface/RecoMEt.h
+++ b/interface/RecoMEt.h
@@ -47,10 +47,9 @@ public:
   Double_t genPt() const;
   Double_t genPhi() const;
 
+
   friend class RecoMEtReader;
   friend class RecoMEtWriter;
-
-protected:
 
   struct MEt
   {
@@ -59,6 +58,12 @@ protected:
     MEt(Float_t pt,
         Float_t phi);
 
+    double
+    px() const;
+
+    double
+    py() const;
+
     MEt &
     operator=(const MEt & other);
 
@@ -66,8 +71,27 @@ protected:
     Float_t phi_; ///< phi of missing transverse momentum vector
   };
 
+  void
+  set_default(int central_or_shift);
+
+  bool
+  has_systematics(int central_or_shift) const;
+
+  void
+  set_systematics(const MEt & met,
+                  int central_or_shift,
+                  bool replace = false);
+
+  MEt
+  get_systematics(int central_or_shift) const;
+
+  int
+  get_default_systematics() const;
+
+protected:
   MEt default_; ///< Default values
   std::map<int, MEt> systematics_; ///< Needed by RecoMEtReader/Writer
+  int default_systematics_;
 
   Float_t covXX_; ///< XX element of MET resolution matrix
   Float_t covXY_; ///< XY element of MET resolution matrix
@@ -89,6 +113,13 @@ protected:
   void update_cov();
 };
 
-std::ostream& operator<<(std::ostream& stream, const RecoMEt& met);
+std::ostream &
+operator<<(std::ostream& stream,
+           const RecoMEt & met);
+
+std::ostream &
+operator<<(std::ostream & stream,
+           const RecoMEt::MEt & met);
+
 
 #endif // tthAnalysis_HiggsToTauTau_RecoMEt_h

--- a/interface/analysisAuxFunctions.h
+++ b/interface/analysisAuxFunctions.h
@@ -732,10 +732,15 @@ clip(double value,
      double max_value = 10.);
 
 int
-get_ptMassOption_jet(double jet_pt,
-                     double jet_eta,
-                     double jet_phi,
-                     int central_or_shift);
+recompute_jet(double & jet_pt,
+              double jet_eta,
+              double jet_phi,
+              double & jet_mass,
+              int jet_id,
+              const std::map<int, Float_t *> & jet_pt_systematics,
+              const std::map<int, Float_t *> & jet_mass_systematics,
+              int central_or_shift,
+              int jet_idx);
 
 RecoMEt
 recompute_met(const RecoMEt & met_uncorr,

--- a/interface/analysisAuxFunctions.h
+++ b/interface/analysisAuxFunctions.h
@@ -10,6 +10,7 @@
 #include "tthAnalysis/HiggsToTauTau/interface/RecoJetBase.h" // RecoJetBase
 #include "tthAnalysis/HiggsToTauTau/interface/TrigObj.h" // TrigObj
 #include "tthAnalysis/HiggsToTauTau/interface/EventInfo.h" // EventInfo
+#include "tthAnalysis/HiggsToTauTau/interface/RecoMEt.h" // RecoMEt
 
 #include <DataFormats/Math/interface/deltaR.h> // deltaR()
 #include <DataFormats/Math/interface/LorentzVector.h> // math::PtEtaPhiMLorentzVector
@@ -729,5 +730,17 @@ double
 clip(double value,
      double min_value = -10.,
      double max_value = 10.);
+
+int
+get_ptMassOption_jet(double jet_pt,
+                     double jet_eta,
+                     double jet_phi,
+                     int central_or_shift);
+
+RecoMEt
+recompute_met(const RecoMEt & met_uncorr,
+              const std::vector<RecoJet> & jets,
+              int met_option,
+              bool isDEBUG = false);
 
 #endif

--- a/interface/sysUncertOptions.h
+++ b/interface/sysUncertOptions.h
@@ -46,6 +46,13 @@ enum
   // additional sources
   kJetMET_jerUp,                   kJetMET_jerDown, // total JER
   kJetMET_UnclusteredEnUp,         kJetMET_UnclusteredEnDown, // unclustered energy (only for MET)
+  // JER split
+  kJetMET_jerBarrelUp,             kJetMET_jerBarrelDown,
+  kJetMET_jerEndcap1Up,            kJetMET_jerEndcap1Down,
+  kJetMET_jerEndcap2LowPtUp,       kJetMET_jerEndcap2LowPtDown,
+  kJetMET_jerEndcap2HighPtUp,      kJetMET_jerEndcap2HighPtDown,
+  kJetMET_jerForwardLowPtUp,       kJetMET_jerForwardLowPtDown,
+  kJetMET_jerForwardHighPtUp,      kJetMET_jerForwardHighPtDown,
 };
 
 enum class METSyst

--- a/interface/sysUncertOptions.h
+++ b/interface/sysUncertOptions.h
@@ -53,6 +53,7 @@ enum
   kJetMET_jerEndcap2HighPtUp,      kJetMET_jerEndcap2HighPtDown,
   kJetMET_jerForwardLowPtUp,       kJetMET_jerForwardLowPtDown,
   kJetMET_jerForwardHighPtUp,      kJetMET_jerForwardHighPtDown,
+                                   kJetMET_jesHEMDown,
 };
 
 enum class METSyst

--- a/python/analysisSettings.py
+++ b/python/analysisSettings.py
@@ -57,6 +57,8 @@ class systematics(object):
   triggerSF_0l2tau = [ "CMS_ttHl_trigger_0l2tauUp", "CMS_ttHl_trigger_0l2tauDown" ]
   triggerSF_split = triggerSF_2lss + triggerSF_3l + triggerSF_1l1tau + triggerSF_0l2tau
 
+  JES_HEM = "CMS_ttHl_JESHEMDown" # addresses HEM15/16, see https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2000.html
+
   JEC_regrouped = [
     "CMS_ttHl_JESAbsoluteUp",           "CMS_ttHl_JESAbsoluteDown",
     "CMS_ttHl_JESAbsolute_EraUp",       "CMS_ttHl_JESAbsolute_EraDown",
@@ -69,6 +71,7 @@ class systematics(object):
     "CMS_ttHl_JESHF_EraUp",             "CMS_ttHl_JESHF_EraDown",
     "CMS_ttHl_JESRelativeBalUp",        "CMS_ttHl_JESRelativeBalDown",
     "CMS_ttHl_JESRelativeSample_EraUp", "CMS_ttHl_JESRelativeSample_EraDown",
+    JES_HEM,
   ]
 
   JER_split = [

--- a/python/analysisSettings.py
+++ b/python/analysisSettings.py
@@ -71,6 +71,15 @@ class systematics(object):
     "CMS_ttHl_JESRelativeSample_EraUp", "CMS_ttHl_JESRelativeSample_EraDown",
   ]
 
+  JER_split = [
+    "CMS_ttHl_JERBarrelUp",        "CMS_ttHl_JERBarrelDown",
+    "CMS_ttHl_JEREndcap1Up",       "CMS_ttHl_JEREndcap1Down",
+    "CMS_ttHl_JEREndcap2LowPtUp",  "CMS_ttHl_JEREndcap2LowPtDown",
+    "CMS_ttHl_JEREndcap2HighPtUp", "CMS_ttHl_JEREndcap2HighPtDown",
+    "CMS_ttHl_JERForwardLowPtUp",  "CMS_ttHl_JERForwardLowPtDown",
+    "CMS_ttHl_JERForwardHighPtUp", "CMS_ttHl_JERForwardHighPtDown",
+  ]
+
   MEM_3l        = [ "CMS_ttHl_MEM_3l_LRUp",        "CMS_ttHl_MEM_3l_LRDown"        ]
   MEM_2lss_1tau = [ "CMS_ttHl_MEM_2lss_1tau_LRUp", "CMS_ttHl_MEM_2lss_1tau_LRDown" ]
   MEM_3l_1tau   = [ "CMS_ttHl_MEM_3l_1tau_LRUp",   "CMS_ttHl_MEM_3l_1tau_LRDown"   ]

--- a/python/configs/analyzeConfig.py
+++ b/python/configs/analyzeConfig.py
@@ -1216,7 +1216,7 @@ class analyzeConfig(object):
     def createCfg_makePlots_addShapes(self, lines):
         central_or_shifts_prefix = []
         for central_or_shift in self.central_or_shifts:
-            if central_or_shift in systematics.JEC_regrouped:
+            if central_or_shift in systematics.JEC_regrouped or central_or_shift in systematics.JER_split:
                 continue
             if central_or_shift.startswith('CMS_ttHl_FR'):
                 continue

--- a/python/configs/analyzeConfig.py
+++ b/python/configs/analyzeConfig.py
@@ -199,6 +199,10 @@ class analyzeConfig(object):
             for central_or_shift in dymc_sys:
               self.central_or_shifts.remove(central_or_shift)
         # ------------------------------------------------------------------------
+        if self.era != "2018":
+          if systematics.JES_HEM in self.central_or_shifts:
+            logging.warning('Removing systematics {} from {} era'.format(systematics.JES_HEM, self.era))
+            self.central_or_shifts.remove(systematics.JES_HEM)
 
         self.jet_cleaning_by_index = jet_cleaning_by_index
         self.gen_matching_by_index = gen_matching_by_index

--- a/python/configs/syncNtupleConfig.py
+++ b/python/configs/syncNtupleConfig.py
@@ -65,7 +65,7 @@ class syncNtupleConfig:
         use_preselected,
         jet_cleaning,
         gen_matching,
-        regroup_jec = False,
+        regroup_jerc = False,
         project_dir = os.path.join(os.getenv('CMSSW_BASE'), 'src', 'tthAnalysis', 'HiggsToTauTau'),
         file_pattern = 'tthAnalyzeRun_%s.py',
         suffix = '',
@@ -121,7 +121,7 @@ class syncNtupleConfig:
       additional_args += " -w %s" % tau_id_wp
     if self.running_method:
       additional_args += " -R %s" % self.running_method
-    if regroup_jec:
+    if regroup_jerc:
       additional_args += " -G"
 
     mem_channels = [ '2lss_1tau', '3l', 'hh_bb2l' ]

--- a/python/runConfig.py
+++ b/python/runConfig.py
@@ -232,10 +232,10 @@ class tthAnalyzeParser(argparse.ArgumentParser):
         help = 'M|do not run data',
     )
 
-  def enable_regrouped_jec(self):
-    self.add_argument('-G', '--enable-regrouped-jec',
-      dest = 'enable_regrouped_jec', action = 'store_true', default = False,
-      help = 'R|Enable regrouped JEC',
+  def enable_regrouped_jerc(self):
+    self.add_argument('-G', '--enable-regrouped-jerc',
+      dest = 'enable_regrouped_jerc', action = 'store_true', default = False,
+      help = 'R|Enable regrouped JEC/JER',
     )
 
   def add_split_trigger_sys(self, default = 'no'):

--- a/src/RecoJetReader.cc
+++ b/src/RecoJetReader.cc
@@ -348,23 +348,27 @@ RecoJetReader::read() const
         btagCSV = -2.;
       }
 
+      double jet_pt = gInstance->jet_pt_systematics_.at(ptMassOption_branch_)[idxJet];
       const double jet_eta = gInstance->jet_eta_[idxJet];
       const double jet_phi = gInstance->jet_phi_[idxJet];
+      double jet_mass = gInstance->jet_mass_systematics_.at(ptMassOption_branch_)[idxJet];
+      const int jet_id = gInstance->jet_jetId_[idxJet];
       const int ptMassOption = ptMassOption_branch_ != ptMassOption_ ?
-        get_ptMassOption_jet(
-          gInstance->jet_pt_systematics_.at(kJetMET_central)[idxJet],
-          jet_eta,
-          jet_phi,
-          ptMassOption_
-        ) : ptMassOption_branch_
+        recompute_jet(
+          jet_pt, jet_eta, jet_phi, jet_mass, jet_id,
+          gInstance->jet_pt_systematics_,
+          gInstance->jet_mass_systematics_,
+          ptMassOption_, idxJet
+        ) :
+        ptMassOption_branch_
       ;
 
       jets.push_back({
         {
-          gInstance->jet_pt_systematics_.at(ptMassOption)[idxJet],
+          jet_pt,
           jet_eta,
           jet_phi,
-          gInstance->jet_mass_systematics_.at(ptMassOption)[idxJet],
+          jet_mass,
         },
         gInstance->jet_charge_[idxJet],
         btagCSV,
@@ -373,7 +377,7 @@ RecoJetReader::read() const
         gInstance->jet_pullEta_[idxJet],
         gInstance->jet_pullPhi_[idxJet],
         gInstance->jet_pullMag_[idxJet],
-        gInstance->jet_jetId_[idxJet],
+        jet_id,
         gInstance->jet_puId_[idxJet],
         gInstance->jet_genMatchIdx_[idxJet],
         gInstance->jet_jetIdx_[idxJet],

--- a/src/RecoJetReader.cc
+++ b/src/RecoJetReader.cc
@@ -34,6 +34,7 @@ RecoJetReader::RecoJetReader(int era,
   , btag_(Btag::kDeepJet)
   , btag_central_or_shift_(kBtag_central)
   , ptMassOption_(isMC_ ? kJetMET_central : kJetMET_central_nonNominal)
+  , ptMassOption_branch_(ptMassOption_)
   , read_ptMass_systematics_(false)
   , read_btag_systematics_(false)
   , jet_eta_(nullptr)
@@ -115,6 +116,23 @@ RecoJetReader::setPtMass_central_or_shift(int central_or_shift)
     throw cmsException(this, __func__, __LINE__) << "Invalid option for the era = " << era_ << ": " << central_or_shift;
   }
   ptMassOption_ = central_or_shift;
+  read_systematics_whitelist_.clear();
+
+  if(central_or_shift <= kJetMET_jerDown)
+  {
+    ptMassOption_branch_ = ptMassOption_;
+  }
+  else
+  {
+    // we already know that we don't want to consider all possible jet branches
+    read_ptMass_systematics(true);
+    read_systematics_whitelist_ = { kJetMET_central, kJetMET_jerUp, kJetMET_jerDown };
+    std::cout
+        << get_human_line(this, __func__, __LINE__)
+        << "Not setting the systematics option to " << ptMassOption_
+        << " but keeping it at " << ptMassOption_branch_
+    ;
+  }
 }
 
 void
@@ -230,8 +248,8 @@ RecoJetReader::setBranchAddresses(TTree * tree)
       genHadTauReader_->setBranchAddresses(tree);
       genJetReader_->setBranchAddresses(tree);
     }
-    bai.setBranchAddress(jet_pt_systematics_[ptMassOption_],   branchNames_pt_systematics_[ptMassOption_]);
-    bai.setBranchAddress(jet_mass_systematics_[ptMassOption_], branchNames_mass_systematics_[ptMassOption_]);
+    bai.setBranchAddress(jet_pt_systematics_[ptMassOption_branch_],   branchNames_pt_systematics_[ptMassOption_branch_]);
+    bai.setBranchAddress(jet_mass_systematics_[ptMassOption_branch_], branchNames_mass_systematics_[ptMassOption_branch_]);
     if(isMC_ && read_ptMass_systematics_)
     {
       for(int idxShift = kJetMET_central_nonNominal; idxShift <= kJetMET_jerDown; ++idxShift)
@@ -240,9 +258,18 @@ RecoJetReader::setBranchAddresses(TTree * tree)
         {
           continue;
         }
-        if(idxShift == ptMassOption_)
+        if(idxShift == ptMassOption_branch_)
         {
           continue; // do not bind the same branch twice
+        }
+        if(! read_systematics_whitelist_.empty() &&
+           std::find(
+             read_systematics_whitelist_.cbegin(),
+             read_systematics_whitelist_.cend(),
+             idxShift
+           ) == read_systematics_whitelist_.cend())
+        {
+          continue; // if there's a whitelist, continue
         }
         bai.setBranchAddress(jet_pt_systematics_[idxShift],   branchNames_pt_systematics_[idxShift]);
         bai.setBranchAddress(jet_mass_systematics_[idxShift], branchNames_mass_systematics_[idxShift]);
@@ -321,12 +348,23 @@ RecoJetReader::read() const
         btagCSV = -2.;
       }
 
+      const double jet_eta = gInstance->jet_eta_[idxJet];
+      const double jet_phi = gInstance->jet_phi_[idxJet];
+      const int ptMassOption = ptMassOption_branch_ != ptMassOption_ ?
+        get_ptMassOption_jet(
+          gInstance->jet_pt_systematics_.at(kJetMET_central)[idxJet],
+          jet_eta,
+          jet_phi,
+          ptMassOption_
+        ) : ptMassOption_branch_
+      ;
+
       jets.push_back({
         {
-          gInstance->jet_pt_systematics_.at(ptMassOption_)[idxJet],
-          gInstance->jet_eta_[idxJet],
-          gInstance->jet_phi_[idxJet],
-          gInstance->jet_mass_systematics_.at(ptMassOption_)[idxJet]
+          gInstance->jet_pt_systematics_.at(ptMassOption)[idxJet],
+          jet_eta,
+          jet_phi,
+          gInstance->jet_mass_systematics_.at(ptMassOption)[idxJet],
         },
         gInstance->jet_charge_[idxJet],
         btagCSV,
@@ -340,6 +378,7 @@ RecoJetReader::read() const
         gInstance->jet_genMatchIdx_[idxJet],
         gInstance->jet_jetIdx_[idxJet],
         btag_,
+        ptMassOption,
       });
 
       RecoJet & jet = jets.back();
@@ -380,6 +419,15 @@ RecoJetReader::read() const
           {
             continue;
           }
+          if(! read_systematics_whitelist_.empty() &&
+             std::find(
+               read_systematics_whitelist_.cbegin(),
+               read_systematics_whitelist_.cend(),
+               idxShift
+             ) == read_systematics_whitelist_.cend())
+          {
+            continue; // if there's a whitelist, continue
+          }
           // we want to save all pT-s and masses that have been shifted by systematic uncertainties to the maps,
           // including the central nominal and central non-nominal values; crucial for RecoJetWriter
           jet.pt_systematics_[idxShift]   = gInstance->jet_pt_systematics_.at(idxShift)[idxJet];
@@ -389,8 +437,8 @@ RecoJetReader::read() const
       else
       {
         // fill the maps with only the central values (either nominal or non-nominal if data)
-        jet.pt_systematics_[ptMassOption_]   = gInstance->jet_pt_systematics_.at(ptMassOption_)[idxJet];
-        jet.mass_systematics_[ptMassOption_] = gInstance->jet_mass_systematics_.at(ptMassOption_)[idxJet];
+        jet.pt_systematics_[ptMassOption_branch_]   = gInstance->jet_pt_systematics_.at(ptMassOption_branch_)[idxJet];
+        jet.mass_systematics_[ptMassOption_branch_] = gInstance->jet_mass_systematics_.at(ptMassOption_branch_)[idxJet];
       } // isMC_
 
     } // idxJet

--- a/src/RecoJetWriter.cc
+++ b/src/RecoJetWriter.cc
@@ -147,7 +147,19 @@ RecoJetWriter::setPtMass_central_or_shift(int central_or_shift)
   {
     throw cmsException(this, __func__, __LINE__) << "Invalid option for the era = " << era_ << ": " << central_or_shift;
   }
-  ptMassOption_ = central_or_shift;
+
+  if(central_or_shift <= kJetMET_jerDown)
+  {
+    ptMassOption_ = central_or_shift;
+  }
+  else
+  {
+    std::cout
+        << get_human_line(this, __func__, __LINE__)
+        << "Not setting the systematics option to " << central_or_shift
+        << " but keeping it at " << ptMassOption_
+    ;
+  }
 }
 
 void

--- a/src/RecoMEt.cc
+++ b/src/RecoMEt.cc
@@ -236,6 +236,6 @@ std::ostream &
 operator<<(std::ostream & stream,
            const RecoMEt::MEt & met)
 {
-  stream << " pT = " << met.pt_ << " phi = " << met.phi_;
+  stream << "pT = " << met.pt_ << " phi = " << met.phi_;
   return stream;
 }

--- a/src/RecoMEtReader.cc
+++ b/src/RecoMEtReader.cc
@@ -50,7 +50,18 @@ RecoMEtReader::setMEt_central_or_shift(int central_or_shift)
   {
     throw cmsException(this, __func__, __LINE__) << "Invalid option for the era = " << era_ << ": " << central_or_shift;
   }
-  ptPhiOption_ = central_or_shift;
+  if(central_or_shift <= kJetMET_UnclusteredEnDown)
+  {
+    ptPhiOption_ = central_or_shift;
+  }
+  else
+  {
+    std::cout
+        << get_human_line(this, __func__, __LINE__)
+        << "Not setting the systematics option to " << central_or_shift
+        << " but keeping it at " << ptPhiOption_
+    ;
+  }
 }
 
 void
@@ -126,7 +137,6 @@ RecoMEtReader::read() const
   const RecoMEtReader * const gInstance = instances_[branchName_obj_];
   assert(gInstance);
   RecoMEt met = met_;
-  met.default_ = met.systematics_[ptPhiOption_];
-  met.update(); // update cov and p4
+  met.set_default(ptPhiOption_);
   return met;
 }

--- a/src/RecoMEtWriter.cc
+++ b/src/RecoMEtWriter.cc
@@ -54,7 +54,18 @@ RecoMEtWriter::setPtPhi_central_or_shift(int central_or_shift)
   {
     throw cmsException(this, __func__, __LINE__) << "Invalid option for the era = " << era_ << ": " << central_or_shift;
   }
-  ptPhiOption_ = central_or_shift;
+  if(central_or_shift <= kJetMET_UnclusteredEnDown)
+  {
+    ptPhiOption_ = central_or_shift;
+  }
+  else
+  {
+    std::cout
+        << get_human_line(this, __func__, __LINE__)
+        << "Not setting the systematics option to " << central_or_shift
+        << " but keeping it at " << ptPhiOption_
+    ;
+  }
 }
 
 void

--- a/src/sysUncertOptions.cc
+++ b/src/sysUncertOptions.cc
@@ -7,10 +7,13 @@
 #include <boost/algorithm/string/predicate.hpp> // boost::algorithm::starts_with(), boost::algorithm::ends_with()
 
 bool
-isValidJESsource(int __attribute__((unused)) era,
-                 int __attribute__((unused)) central_or_shift)
+isValidJESsource(int era,
+                 int central_or_shift)
 {
-  // keeping for future compatibility
+  if(central_or_shift == kJetMET_jesHEMDown && era != kEra_2018)
+  {
+    return false;
+  }
   return true;
 }
 
@@ -82,6 +85,7 @@ getJet_option(const std::string & central_or_shift,
   else if(central_or_shift == "CMS_ttHl_JERForwardLowPtDown"      ) central_or_shift_int = kJetMET_jerForwardLowPtDown;
   else if(central_or_shift == "CMS_ttHl_JERForwardHighPtUp"       ) central_or_shift_int = kJetMET_jerForwardHighPtUp;
   else if(central_or_shift == "CMS_ttHl_JERForwardHighPtDown"     ) central_or_shift_int = kJetMET_jerForwardHighPtDown;
+  else if(central_or_shift == "CMS_ttHl_JESHEMDown"               ) central_or_shift_int = kJetMET_jesHEMDown;
   return central_or_shift_int;
 }
 

--- a/src/sysUncertOptions.cc
+++ b/src/sysUncertOptions.cc
@@ -70,6 +70,18 @@ getJet_option(const std::string & central_or_shift,
   else if(central_or_shift == "CMS_ttHl_JESRelativeBalDown"       ) central_or_shift_int = kJetMET_jesRelativeBalDown;
   else if(central_or_shift == "CMS_ttHl_JESRelativeSample_EraUp"  ) central_or_shift_int = kJetMET_jesRelativeSample_EraUp;
   else if(central_or_shift == "CMS_ttHl_JESRelativeSample_EraDown") central_or_shift_int = kJetMET_jesRelativeSample_EraDown;
+  else if(central_or_shift == "CMS_ttHl_JERBarrelUp"              ) central_or_shift_int = kJetMET_jerBarrelUp;
+  else if(central_or_shift == "CMS_ttHl_JERBarrelDown"            ) central_or_shift_int = kJetMET_jerBarrelDown;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap1Up"             ) central_or_shift_int = kJetMET_jerEndcap1Up;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap1Down"           ) central_or_shift_int = kJetMET_jerEndcap1Down;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap2LowPtUp"        ) central_or_shift_int = kJetMET_jerEndcap2LowPtUp;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap2LowPtDown"      ) central_or_shift_int = kJetMET_jerEndcap2LowPtDown;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap2HighPtUp"       ) central_or_shift_int = kJetMET_jerEndcap2HighPtUp;
+  else if(central_or_shift == "CMS_ttHl_JEREndcap2HighPtDown"     ) central_or_shift_int = kJetMET_jerEndcap2HighPtDown;
+  else if(central_or_shift == "CMS_ttHl_JERForwardLowPtUp"        ) central_or_shift_int = kJetMET_jerForwardLowPtUp;
+  else if(central_or_shift == "CMS_ttHl_JERForwardLowPtDown"      ) central_or_shift_int = kJetMET_jerForwardLowPtDown;
+  else if(central_or_shift == "CMS_ttHl_JERForwardHighPtUp"       ) central_or_shift_int = kJetMET_jerForwardHighPtUp;
+  else if(central_or_shift == "CMS_ttHl_JERForwardHighPtDown"     ) central_or_shift_int = kJetMET_jerForwardHighPtDown;
   return central_or_shift_int;
 }
 
@@ -77,35 +89,9 @@ int
 getMET_option(const std::string & central_or_shift,
               bool isMC)
 {
-  int central_or_shift_int = isMC ? kJetMET_central : kJetMET_central_nonNominal;
-  if     (central_or_shift == "CMS_ttHl_JESUp"                    ) central_or_shift_int = kJetMET_jesUp;
-  else if(central_or_shift == "CMS_ttHl_JESDown"                  ) central_or_shift_int = kJetMET_jesDown;
-  else if(central_or_shift == "CMS_ttHl_JERUp"                    ) central_or_shift_int = kJetMET_jerUp;
-  else if(central_or_shift == "CMS_ttHl_JERDown"                  ) central_or_shift_int = kJetMET_jerDown;
-  else if(central_or_shift == "CMS_ttHl_UnclusteredEnUp"          ) central_or_shift_int = kJetMET_UnclusteredEnUp;
-  else if(central_or_shift == "CMS_ttHl_UnclusteredEnDown"        ) central_or_shift_int = kJetMET_UnclusteredEnDown;
-  else if(central_or_shift == "CMS_ttHl_JESAbsoluteUp"            ) central_or_shift_int = kJetMET_jesAbsoluteUp;
-  else if(central_or_shift == "CMS_ttHl_JESAbsoluteDown"          ) central_or_shift_int = kJetMET_jesAbsoluteDown;
-  else if(central_or_shift == "CMS_ttHl_JESAbsolute_EraUp"        ) central_or_shift_int = kJetMET_jesAbsolute_EraUp;
-  else if(central_or_shift == "CMS_ttHl_JESAbsolute_EraDown"      ) central_or_shift_int = kJetMET_jesAbsolute_EraDown;
-  else if(central_or_shift == "CMS_ttHl_JESBBEC1Up"               ) central_or_shift_int = kJetMET_jesBBEC1Up;
-  else if(central_or_shift == "CMS_ttHl_JESBBEC1Down"             ) central_or_shift_int = kJetMET_jesBBEC1Down;
-  else if(central_or_shift == "CMS_ttHl_JESBBEC1_EraUp"           ) central_or_shift_int = kJetMET_jesBBEC1_EraUp;
-  else if(central_or_shift == "CMS_ttHl_JESBBEC1_EraDown"         ) central_or_shift_int = kJetMET_jesBBEC1_EraDown;
-  else if(central_or_shift == "CMS_ttHl_JESEC2Up"                 ) central_or_shift_int = kJetMET_jesEC2Up;
-  else if(central_or_shift == "CMS_ttHl_JESEC2Down"               ) central_or_shift_int = kJetMET_jesEC2Down;
-  else if(central_or_shift == "CMS_ttHl_JESEC2_EraUp"             ) central_or_shift_int = kJetMET_jesEC2_EraUp;
-  else if(central_or_shift == "CMS_ttHl_JESEC2_EraDown"           ) central_or_shift_int = kJetMET_jesEC2_EraDown;
-  else if(central_or_shift == "CMS_ttHl_JESFlavorQCDUp"           ) central_or_shift_int = kJetMET_jesFlavorQCDUp;
-  else if(central_or_shift == "CMS_ttHl_JESFlavorQCDDown"         ) central_or_shift_int = kJetMET_jesFlavorQCDDown;
-  else if(central_or_shift == "CMS_ttHl_JESHFUp"                  ) central_or_shift_int = kJetMET_jesHFUp;
-  else if(central_or_shift == "CMS_ttHl_JESHFDown"                ) central_or_shift_int = kJetMET_jesHFDown;
-  else if(central_or_shift == "CMS_ttHl_JESHF_EraUp"              ) central_or_shift_int = kJetMET_jesHF_EraUp;
-  else if(central_or_shift == "CMS_ttHl_JESHF_EraDown"            ) central_or_shift_int = kJetMET_jesHF_EraDown;
-  else if(central_or_shift == "CMS_ttHl_JESRelativeBalUp"         ) central_or_shift_int = kJetMET_jesRelativeBalUp;
-  else if(central_or_shift == "CMS_ttHl_JESRelativeBalDown"       ) central_or_shift_int = kJetMET_jesRelativeBalDown;
-  else if(central_or_shift == "CMS_ttHl_JESRelativeSample_EraUp"  ) central_or_shift_int = kJetMET_jesRelativeSample_EraUp;
-  else if(central_or_shift == "CMS_ttHl_JESRelativeSample_EraDown") central_or_shift_int = kJetMET_jesRelativeSample_EraDown;
+  int central_or_shift_int = isMC ? getJet_option(central_or_shift, isMC) : kJetMET_central_nonNominal;
+  if     (central_or_shift == "CMS_ttHl_UnclusteredEnUp"  ) central_or_shift_int = kJetMET_UnclusteredEnUp;
+  else if(central_or_shift == "CMS_ttHl_UnclusteredEnDown") central_or_shift_int = kJetMET_UnclusteredEnDown;
   return central_or_shift_int;
 }
 

--- a/test/tthAnalyzeRun_0l_2tau.py
+++ b/test/tthAnalyzeRun_0l_2tau.py
@@ -33,7 +33,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.do_MC_only()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -63,13 +63,13 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 MC_only           = args.MC_only
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_1l_1tau.py
+++ b/test/tthAnalyzeRun_1l_1tau.py
@@ -32,7 +32,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.do_MC_only()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -61,13 +61,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 MC_only           = args.MC_only
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_1l_2tau.py
+++ b/test/tthAnalyzeRun_1l_2tau.py
@@ -32,7 +32,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.do_MC_only()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -62,13 +62,13 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 MC_only           = args.MC_only
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_2l_2tau.py
+++ b/test/tthAnalyzeRun_2l_2tau.py
@@ -31,7 +31,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -60,13 +60,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_2los_1tau.py
+++ b/test/tthAnalyzeRun_2los_1tau.py
@@ -30,7 +30,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.do_MC_only()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -59,13 +59,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
 MC_only           = args.MC_only
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_2lss.py
+++ b/test/tthAnalyzeRun_2lss.py
@@ -29,7 +29,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_tau_id()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 parser.add_stitched()
 args = parser.parse_args()
@@ -58,14 +58,14 @@ use_home          = args.use_home
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 use_stitched      = args.use_stitched
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_2lss_1tau.py
+++ b/test/tthAnalyzeRun_2lss_1tau.py
@@ -34,7 +34,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -63,13 +63,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_3l.py
+++ b/test/tthAnalyzeRun_3l.py
@@ -34,7 +34,7 @@ parser.add_gen_matching()
 parser.add_sideband()
 parser.add_tau_id()
 parser.add_control_region()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -64,13 +64,13 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 control_region    = args.control_region
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_3l_1tau.py
+++ b/test/tthAnalyzeRun_3l_1tau.py
@@ -33,7 +33,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -62,13 +62,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_4l.py
+++ b/test/tthAnalyzeRun_4l.py
@@ -31,7 +31,7 @@ parser.add_gen_matching()
 parser.add_sideband()
 parser.add_tau_id()
 parser.add_control_region()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -61,13 +61,13 @@ gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
 control_region    = args.control_region
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_WZctrl.py
+++ b/test/tthAnalyzeRun_WZctrl.py
@@ -29,7 +29,7 @@ parser.add_rle_select()
 parser.add_nonnominal()
 parser.add_hlt_filter()
 parser.add_tau_id()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -57,13 +57,13 @@ hlt_filter        = args.hlt_filter
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_ZZctrl.py
+++ b/test/tthAnalyzeRun_ZZctrl.py
@@ -30,7 +30,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sideband()
 parser.add_tau_id()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -59,13 +59,13 @@ jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 sideband          = args.sideband
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_inclusive.py
+++ b/test/tthAnalyzeRun_inclusive.py
@@ -24,7 +24,7 @@ parser.add_tau_id()
 parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_argument('-o', '--output-tree',
   type = str, dest = 'output_tree', metavar = 'name', default = 'syncTree', required = False,
   help = 'R|Output TTree name',
@@ -55,16 +55,16 @@ use_home          = args.use_home
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 
 # Custom arguments
 output_tree = args.output_tree
 tau_wp_ak8  = args.tau_wp_ak8
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 
 # Use the arguments
 central_or_shifts = []

--- a/test/tthAnalyzeRun_ttWctrl.py
+++ b/test/tthAnalyzeRun_ttWctrl.py
@@ -29,7 +29,7 @@ parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_hlt_filter()
 parser.add_tau_id()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -57,13 +57,13 @@ hlt_filter        = args.hlt_filter
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthAnalyzeRun_ttZctrl.py
+++ b/test/tthAnalyzeRun_ttZctrl.py
@@ -30,7 +30,7 @@ parser.add_lep_mva_wp(default_wp = 'default') # alternative: ttZctrl
 parser.add_nonnominal()
 parser.add_hlt_filter()
 parser.add_tau_id()
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_split_trigger_sys()
 args = parser.parse_args()
 
@@ -59,13 +59,13 @@ hlt_filter        = args.hlt_filter
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 split_trigger_sys = args.split_trigger_sys
 
-if regroup_jec:
+if regroup_jerc:
   if 'full' not in systematics_label:
-    raise RuntimeError("Regrouped JEC was enabled but not running with full systematics")
-  systematics.full.extend(systematics.JEC_regrouped)
+    raise RuntimeError("Regrouped JEC or split JER was enabled but not running with full systematics")
+  systematics.full.extend(systematics.JEC_regrouped + systematics.JER_split)
 if split_trigger_sys == 'yes':
   for trigger_sys in systematics.triggerSF:
     del systematics.internal[systematics.internal.index(trigger_sys)]

--- a/test/tthSyncNtuple.py
+++ b/test/tthSyncNtuple.py
@@ -83,7 +83,7 @@ parser.add_use_home()
 parser.add_jet_cleaning()
 parser.add_gen_matching()
 parser.add_sys(sys_choices)
-parser.enable_regrouped_jec()
+parser.enable_regrouped_jerc()
 parser.add_preselect()
 parser.add_argument('-c', '--channels',
   type = str, nargs = '+', dest = 'channels', metavar = 'channel', choices = channel_choices,
@@ -124,7 +124,7 @@ use_preselected   = args.use_preselected
 jet_cleaning      = args.jet_cleaning
 gen_matching      = args.gen_matching
 tau_id            = args.tau_id
-regroup_jec       = args.enable_regrouped_jec
+regroup_jerc      = args.enable_regrouped_jerc
 
 # Custom arguments
 channels = args.channels
@@ -160,7 +160,7 @@ if __name__ == '__main__':
     use_preselected    = use_preselected,
     jet_cleaning       = jet_cleaning,
     gen_matching       = gen_matching,
-    regroup_jec        = regroup_jec,
+    regroup_jerc       = regroup_jerc,
     submission_cmd     = sys.argv,
   )
 


### PR DESCRIPTION
Solves issues https://github.com/HEP-KBFI/tth-htt/issues/126, https://github.com/HEP-KBFI/tth-htt/issues/130

Do not merge.

This needs to be thoroughly tested, because I had to edit some very basic classes. I only tested 2lss+1tau analysis using central values, JER up, JER barrel up, and HEM, in 2017 and in 2018. Thus far, it seems to work, plus the recomputed MET is reasonable, but I don't think it's enough. The following cases should be tested using the same set of systematics:
- analysis on data -- I may consider running a full analysis workflow with the above systematics;
- post-processing on data & MC -- reproduce sync Ntuple (MC) + run post-production for a data Ntuple locally;
- MEM -- test using sync Ntuple.